### PR TITLE
Fix: 특정식사의상세정보반환api header에 Authorization 적용

### DIFF
--- a/src/main/java/mealplanb/server/controller/FoodController.java
+++ b/src/main/java/mealplanb/server/controller/FoodController.java
@@ -10,6 +10,7 @@ import mealplanb.server.dto.food.PostNewFoodResponse;
 import mealplanb.server.dto.user.PostMemberRequest;
 import mealplanb.server.dto.user.PostMemberResponse;
 import mealplanb.server.service.FoodService;
+import mealplanb.server.util.jwt.JwtProvider;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -23,16 +24,17 @@ import static mealplanb.server.util.BindingResultUtils.getErrorMessages;
 @RequestMapping("/food")
 public class FoodController {
     private final FoodService foodService;
+    private final JwtProvider jwtProvider;
 
     /**
      * 특정 식사의 상세 정보 반환
      */
     @GetMapping("/{foodId}")
-    public BaseResponse<GetFoodResponse> getFoodDetail(@PathVariable long foodId) {
+    public BaseResponse<GetFoodResponse> getFoodDetail(@RequestHeader("Authorization") String authorization,
+                                                       @PathVariable long foodId) {
         System.out.println("[FoodController.getFoodDetail]");
-        long memberId = 1; // TODO: 이 부분은 나중에 Header의 jwt에서 값을 얻어야할 것 같다.
+        Long memberId = jwtProvider.extractIdFromHeader(authorization);
         return new BaseResponse<>(foodService.getFoodDetail(memberId, foodId));
-
     }
 
     /**


### PR DESCRIPTION
## 개요
-  header에 Authorization을 적용하였습니다.

## 작업사항
- 기존에 특정식사의 상세정보 반환 api 작업할 때는 jwt 작업이 진행 중이었어서, 더미값으로 넣어뒀던 memberId를 Authorization에서 꺼내 읽게끔 수정하였습니다.
- 포스트맨으로 정상 작동하는 것 확인하였습니다.

## 주의사항
- 