### PR TITLE
Fix: MEAL-122-BE-나의식단api

### DIFF
--- a/src/main/java/mealplanb/server/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/mealplanb/server/common/response/status/BaseExceptionResponseStatus.java
@@ -63,10 +63,9 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     INVALID_MEAL_VALUE(7000, HttpStatus.BAD_REQUEST.value(), "식단 요청에서 잘못된 값이 존재합니다."),
     MEAL_NOT_FOUND(7001, HttpStatus.NOT_FOUND.value(), "식단을 찾을 수 없습니다."),
     DUPLICATE_MEAL(7003, HttpStatus.BAD_REQUEST.value(), "이미 존재하는 식단입니다."),
-    UNAUTHORIZED_ACCESS(7004, HttpStatus.UNAUTHORIZED.value() , "해당 식단에 대해 권한이 없는 멤버입니다."),
-    FAVORITE_MEAL_NAME_ALREADY_EXIST(7005, HttpStatus.UNAUTHORIZED.value() , "해당 이름을 가진 식단이 이미 존재합니다."),
-    FAVORITE_MEAL_NOT_EXIST(5008,HttpStatus.BAD_REQUEST.value(), "해당 유저의 나의 식단이 존재하지 않습니다."),
-    FAVORITE_MEAL_COMPONENT_NOT_EXIST(5009, HttpStatus.BAD_REQUEST.value(), "나의 식단에 들어있는 식사가 없습니다."),
+    FAVORITE_MEAL_NAME_ALREADY_EXIST(7004, HttpStatus.UNAUTHORIZED.value() , "해당 이름을 가진 식단이 이미 존재합니다."),
+    FAVORITE_MEAL_NOT_EXIST(7005,HttpStatus.BAD_REQUEST.value(), "해당 유저의 나의 식단이 존재하지 않습니다."),
+    FAVORITE_MEAL_COMPONENT_NOT_EXIST(7006, HttpStatus.BAD_REQUEST.value(), "나의 식단에 들어있는 식사가 없습니다."),
 
     /**
      * 8000: Weight 오류

--- a/src/main/java/mealplanb/server/controller/FavoriteMealController.java
+++ b/src/main/java/mealplanb/server/controller/FavoriteMealController.java
@@ -47,13 +47,12 @@ public class FavoriteMealController {
      * 나의 식단 삭제
      */
 
-    @PatchMapping("")
+    @PatchMapping("/{favoriteMealId}")
     public BaseResponse<Void> deleteMyMeal(@RequestHeader("Authorization") String authorization,
                                            @PathVariable Long favoriteMealId){
         log.info("[FavoriteMealController.deleteMyMeal]");
         Long memberId = jwtProvider.extractIdFromHeader(authorization);
         favoriteMealService.deleteMyMeal(memberId, favoriteMealId);
-        favoriteMealComponentService.deleteMyMealComponent(favoriteMealId);
         return new BaseResponse<>(null);
     }
 }

--- a/src/main/java/mealplanb/server/dto/meal/GetMyMealResponse.java
+++ b/src/main/java/mealplanb/server/dto/meal/GetMyMealResponse.java
@@ -22,6 +22,7 @@ public class GetMyMealResponse {
         private long favoriteMealId;
         private String favoriteMealName;
         private int mealKcal;
+        private int foodCount; // 내용물 개수
 
         public FavoriteMealItem(Long favoriteMealId, String favoriteMealName, int totalKcal) {
             this.favoriteMealId = favoriteMealId;

--- a/src/main/java/mealplanb/server/dto/meal/GetMyMealResponse.java
+++ b/src/main/java/mealplanb/server/dto/meal/GetMyMealResponse.java
@@ -24,10 +24,11 @@ public class GetMyMealResponse {
         private int mealKcal;
         private int foodCount; // 내용물 개수
 
-        public FavoriteMealItem(Long favoriteMealId, String favoriteMealName, int totalKcal) {
+        public FavoriteMealItem(Long favoriteMealId, String favoriteMealName, int totalKcal, int foodCount) {
             this.favoriteMealId = favoriteMealId;
             this.favoriteMealName = favoriteMealName;
             this.mealKcal = totalKcal;
+            this.foodCount = foodCount;
         }
     }
 }

--- a/src/main/java/mealplanb/server/repository/FoodRepository.java
+++ b/src/main/java/mealplanb/server/repository/FoodRepository.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 
 public interface FoodRepository extends JpaRepository<Food, Long> {
     Optional<Food> findByFoodIdAndStatus(long foodId, BaseStatus a);
+    Optional<Food> findByFoodId(Long foodId);
 
     @Query(value = "SELECT * " +
             "FROM food " +

--- a/src/main/java/mealplanb/server/service/FavoriteMealComponentService.java
+++ b/src/main/java/mealplanb/server/service/FavoriteMealComponentService.java
@@ -76,7 +76,8 @@ public class FavoriteMealComponentService {
             FavoriteMealItem mealItem = new FavoriteMealItem(
                     favoriteMealId,
                     meal.getFavoriteMealName(),
-                    totalKcal
+                    totalKcal,
+                    favoriteMealComponentList.size()
             );
 
             mealItemList.add(mealItem);

--- a/src/main/java/mealplanb/server/service/FavoriteMealComponentService.java
+++ b/src/main/java/mealplanb/server/service/FavoriteMealComponentService.java
@@ -2,12 +2,14 @@ package mealplanb.server.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import mealplanb.server.common.exception.FoodException;
 import mealplanb.server.common.exception.MealException;
 import mealplanb.server.domain.Base.BaseStatus;
 import mealplanb.server.domain.FavoriteMeal;
 import mealplanb.server.domain.FavoriteMealComponent;
-import mealplanb.server.domain.Food;
+import mealplanb.server.domain.Food.Food;
 import mealplanb.server.dto.meal.GetMyMealResponse.FavoriteMealItem;
+import mealplanb.server.dto.meal.PostMyMealRequest;
 import mealplanb.server.repository.FavoriteMealComponentRepository;
 import mealplanb.server.repository.FoodRepository;
 import org.springframework.stereotype.Service;
@@ -16,8 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
-import static mealplanb.server.common.response.status.BaseExceptionResponseStatus.FAVORITE_MEAL_COMPONENT_NOT_EXIST;
-import static mealplanb.server.common.response.status.BaseExceptionResponseStatus.FAVORITE_MEAL_NOT_EXIST;
+import static mealplanb.server.common.response.status.BaseExceptionResponseStatus.*;
 
 
 @Slf4j
@@ -27,6 +28,29 @@ public class FavoriteMealComponentService {
 
     private final FoodRepository foodRepository;
     private final FavoriteMealComponentRepository favoriteMealComponentRepository;
+
+    /**
+     * 나의 식단 등록
+     */
+    @Transactional
+    public void saveItems(PostMyMealRequest postMyMealRequest,FavoriteMeal favoriteMeal){
+        for (PostMyMealRequest.FoodItem foodItem : postMyMealRequest.getFoods()) {
+            long foodId = foodItem.getFoodId();
+            int quantity = foodItem.getQuantity();
+            Food food = foodRepository.findByFoodId(foodId)
+                    .orElseThrow(() -> new FoodException(FOOD_NOT_FOUND));
+
+            FavoriteMealComponent favoriteMealComponent = FavoriteMealComponent.builder()
+                    .favoriteMeal(favoriteMeal)
+                    .food(food)
+                    .quantity(quantity)
+                    .status(BaseStatus.A)
+                    .build();
+
+            favoriteMealComponentRepository.save(favoriteMealComponent);
+        }
+    }
+
 
     /**
      * 나의 식단 조회

--- a/src/main/java/mealplanb/server/service/FavoriteMealService.java
+++ b/src/main/java/mealplanb/server/service/FavoriteMealService.java
@@ -9,7 +9,7 @@ import mealplanb.server.common.response.status.BaseExceptionResponseStatus;
 import mealplanb.server.domain.Base.BaseStatus;
 import mealplanb.server.domain.FavoriteMeal;
 import mealplanb.server.domain.FavoriteMealComponent;
-import mealplanb.server.domain.Food;
+import mealplanb.server.domain.Food.Food;
 import mealplanb.server.domain.Member.Member;
 import mealplanb.server.dto.meal.GetMyMealResponse;
 import mealplanb.server.dto.meal.GetMyMealResponse.FavoriteMealItem;
@@ -57,22 +57,7 @@ public class FavoriteMealService {
 
         favoriteMealRepository.save(favoriteMeal);
 
-        // 이 부분을 FavoriteMealComponentService 로 빼야하는지..
-        for (PostMyMealRequest.FoodItem foodItem : postMyMealRequest.getFoods()) {
-            long foodId = foodItem.getFoodId();
-            int quantity = foodItem.getQuantity();
-            Food food = foodRepository.findByFoodId(foodId)
-                    .orElseThrow(()-> new FoodException(FOOD_NOT_FOUND));
-
-            FavoriteMealComponent favoriteMealComponent = FavoriteMealComponent.builder()
-                    .favoriteMeal(favoriteMeal)
-                    .food(food)
-                    .quantity(quantity)
-                    .status(BaseStatus.A)
-                    .build();
-
-            favoriteMealComponentRepository.save(favoriteMealComponent);
-        }
+        favoriteMealComponentService.saveItems(postMyMealRequest,favoriteMeal);
     }
 
     private void checkFavoriteMealNameExist(String favoriteMealName) {
@@ -110,6 +95,8 @@ public class FavoriteMealService {
                 .orElseThrow(()->new MealException(FAVORITE_MEAL_NOT_EXIST));
 
         favoriteMeal.updateStatus(BaseStatus.D);
+
+        favoriteMealComponentService.deleteMyMealComponent(favoriteMealId);
     }
 
 }


### PR DESCRIPTION
## 개요
- 기존 나의식단 api 에 음식개수 추가로 보여주고 이전 pr 오류 수정하는 작업 하였습니다.

## 작업사항
- patch 메소드에 pathvariable 매핑이 빠져있어서 /{favoriteMealId} 로 수정하였습니다.
- 이전 리뷰들 전부 반영
- 음식 갯수도 식단별로 보이도록 코드 수정하였습니다.

## 주의사항
```
http://localhost:9000/my-meal
```
<img width="746" alt="스크린샷 2024-02-14 오후 1 07 06" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/122519994/30cfaf8d-e986-4c3a-8fbe-490d1559db5e">

- 나의 식단 등록 테스트 결과 입니다.

```
http://localhost:9000/my-meal
```
<img width="746" alt="스크린샷 2024-02-14 오후 1 07 57" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/122519994/24294a3c-68d9-4e4d-a138-52996b489166">

- 나의 식단 조회 테스트 결과입니다.

```
http://localhost:9000/my-meal/6
```
<img width="746" alt="스크린샷 2024-02-14 오후 1 08 52" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/122519994/9946debe-23a3-4bb5-a6d9-3defe13749a6">

- 나의 식단 삭제 테스트 결과입니다.

- 나의식단을 누르면 바로 끼니 등록 페이지로 넘어갈 수 있도록 foodId 와 quantity 넘기는 api 는 해당 pr 이 머지되고 나서 이 브랜치에서 추가로 작업하도록 하겠습니다.
