### PR TITLE
Fix: Meal-136-BE-채팅(치팅데이)api 코멘트 수정사항 반영

### DIFF
--- a/src/main/java/mealplanb/server/common/exception/ChatException.java
+++ b/src/main/java/mealplanb/server/common/exception/ChatException.java
@@ -1,0 +1,20 @@
+package mealplanb.server.common.exception;
+
+import lombok.Getter;
+import mealplanb.server.common.response.status.ResponseStatus;
+
+@Getter
+public class ChatException extends RuntimeException {
+
+    private final ResponseStatus exceptionStatus;
+
+    public ChatException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+
+    public ChatException(ResponseStatus exceptionStatus, String message) {
+        super(message);
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/src/main/java/mealplanb/server/common/exception_handler/ChatExceptionControllerAdvice.java
+++ b/src/main/java/mealplanb/server/common/exception_handler/ChatExceptionControllerAdvice.java
@@ -1,0 +1,23 @@
+package mealplanb.server.common.exception_handler;
+
+import jakarta.annotation.Priority;
+import lombok.extern.slf4j.Slf4j;
+import mealplanb.server.common.exception.ChatException;
+import mealplanb.server.common.response.BaseErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@Priority(0)
+@RestControllerAdvice
+public class ChatExceptionControllerAdvice {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(ChatException.class)
+    public BaseErrorResponse handle_ChatException(ChatException e) {
+        log.error("[handle_ChatException]", e);
+        return new BaseErrorResponse(e.getExceptionStatus(), e.getMessage());
+    }
+}

--- a/src/main/java/mealplanb/server/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/mealplanb/server/common/response/status/BaseExceptionResponseStatus.java
@@ -71,7 +71,12 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     /**
      * 8000: Weight 오류
      */
-    WEIGHT_NOT_FOUND(8000, HttpStatus.BAD_REQUEST.value(), "해당 유저의 체중을 찾을 수 없습니다.");
+    WEIGHT_NOT_FOUND(8000, HttpStatus.BAD_REQUEST.value(), "해당 유저의 체중을 찾을 수 없습니다."),
+
+    /**
+     * 9000: Chat Controller 오류
+     */
+    CHAT_CHEAT_DAY_LEFT_KCAL_NOT_EXIST(9000, HttpStatus.BAD_REQUEST.value(), "해당 유저의 잔여 칼로리가 없습니다.");
 
     private final int code;
     private final int status;

--- a/src/main/java/mealplanb/server/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/mealplanb/server/common/response/status/BaseExceptionResponseStatus.java
@@ -48,7 +48,6 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     INVALID_USER_STATUS(5005, HttpStatus.BAD_REQUEST.value(), "잘못된 회원 status 값입니다."),
     EMAIL_NOT_FOUND(5006, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 이메일입니다."),
     RATIO_NOT_CORRECT(5007,HttpStatus.BAD_REQUEST.value(), "탄,단,지 비율 합이 100이 되지 않습니다."),
-    UNAUTHORIZED_ACCESS(5008, HttpStatus.UNAUTHORIZED.value() , "권한이 없는 멤버입니다."),
   
     /**
      * 6000: Food 오류
@@ -56,6 +55,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     FOOD_NOT_FOUND(6001, HttpStatus.NOT_FOUND.value(), "식품을 찾을 수 없습니다."),
     FAVORITE_FOOD_NOT_EXIST(6002, HttpStatus.NOT_FOUND.value(), "해당 유저의 즐겨찾기 식품을 찾을 수 없습니다."),
     FAVORITE_FOOD_ALREADY_EXIST(6003, HttpStatus.NOT_FOUND.value(), "이미 즐겨찾기한 식사입니다."),
+    FOOD_UNAUTHORIZED_ACCESS(5008, HttpStatus.UNAUTHORIZED.value() , "식품을 지울 권한이 없는 멤버입니다."),
 
     /**
      * 7000: Meal 오류
@@ -63,7 +63,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     INVALID_MEAL_VALUE(7000, HttpStatus.BAD_REQUEST.value(), "식단 요청에서 잘못된 값이 존재합니다."),
     MEAL_NOT_FOUND(7001, HttpStatus.NOT_FOUND.value(), "식단을 찾을 수 없습니다."),
     DUPLICATE_MEAL(7003, HttpStatus.BAD_REQUEST.value(), "이미 존재하는 식단입니다."),
-    UNAUTHORIZED_ACCESS(7004, HttpStatus.UNAUTHORIZED.value() , "해당 식단에 대해 권한이 없는 멤버입니다."),
+    MEAL_UNAUTHORIZED_ACCESS(7004, HttpStatus.UNAUTHORIZED.value() , "해당 식단에 대해 권한이 없는 멤버입니다."),
     FAVORITE_MEAL_NAME_ALREADY_EXIST(7005, HttpStatus.UNAUTHORIZED.value() , "해당 이름을 가진 식단이 이미 존재합니다."),
     FAVORITE_MEAL_NOT_EXIST(5008,HttpStatus.BAD_REQUEST.value(), "해당 유저의 나의 식단이 존재하지 않습니다."),
     FAVORITE_MEAL_COMPONENT_NOT_EXIST(5009, HttpStatus.BAD_REQUEST.value(), "나의 식단에 들어있는 식사가 없습니다."),

--- a/src/main/java/mealplanb/server/dto/chat/GetCheatDayFoodResponse.java
+++ b/src/main/java/mealplanb/server/dto/chat/GetCheatDayFoodResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class GetCheatDayFoodResponse {
-
+    /** 채팅(치팅데이) */
     private List<cheatDayFoodInfo> cheatDayFood;
 
     @Getter

--- a/src/main/java/mealplanb/server/dto/chat/GetCheatDayFoodResponse.java
+++ b/src/main/java/mealplanb/server/dto/chat/GetCheatDayFoodResponse.java
@@ -20,5 +20,6 @@ public class GetCheatDayFoodResponse {
         private int protein;
         private int fat;
         private String offer;
+        private int quantity;
     }
 }

--- a/src/main/java/mealplanb/server/dto/food/GetFavoriteFoodResponse.java
+++ b/src/main/java/mealplanb/server/dto/food/GetFavoriteFoodResponse.java
@@ -10,9 +10,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class GetFavoriteFoodResponse {
-    /**
-     * 즐겨찾기한 식품 조회
-     */
+    /** 즐겨찾기한 식품 조회 */
     private List<FoodItem> foods;
 
     @Getter

--- a/src/main/java/mealplanb/server/dto/food/PostFavoriteFoodRequest.java
+++ b/src/main/java/mealplanb/server/dto/food/PostFavoriteFoodRequest.java
@@ -9,9 +9,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class PostFavoriteFoodRequest {
 
-    /**
-     * 즐겨찾기 식사 등록
-     */
+    /** 즐겨찾기 식사 등록 */
     //private String name;
     private Long foodId;
 }

--- a/src/main/java/mealplanb/server/dto/meal/MealTypeConverter.java
+++ b/src/main/java/mealplanb/server/dto/meal/MealTypeConverter.java
@@ -4,6 +4,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class MealTypeConverter {
+    /** ex) 1 -> 첫끼로 바꿔주는 컨버터
+     * MealTypeConverter.convertMealTypeLabel(meal.getMealType())
+     * 위와 같이 호출해서 사용 가능 */
+
     private static final Map<Integer, String> MEAL_TYPE_MAP = new HashMap<>();
 
     static {

--- a/src/main/java/mealplanb/server/dto/member/GetDietTypeRequest.java
+++ b/src/main/java/mealplanb/server/dto/member/GetDietTypeRequest.java
@@ -10,8 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 @Setter
 @NoArgsConstructor
 public class GetDietTypeRequest {
-    /**
-     * 사용자 목표 조회 (식단타입에 따른 탄단지 조회)
-     */
+    /** 사용자 목표 조회 (식단타입에 따른 탄단지 조회) */
     private String dietType;
 }

--- a/src/main/java/mealplanb/server/dto/member/GetDietTypeResponse.java
+++ b/src/main/java/mealplanb/server/dto/member/GetDietTypeResponse.java
@@ -6,10 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class GetDietTypeResponse {
-
-    /**
-     * 사용자 목표 조회 (식단타입에 따른 탄단지 조회)
-     */
+    /** 사용자 목표 조회 (식단타입에 따른 탄단지 조회) */
     private String dietType;
     private int carbohydrateRate;
     private int proteinRate;

--- a/src/main/java/mealplanb/server/dto/member/GetPlanResponse.java
+++ b/src/main/java/mealplanb/server/dto/member/GetPlanResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class GetPlanResponse {
-
+    /** 사용자 목표 조회  */
     private double initialWeight;
     private double targetWeight;
     private String dietType;

--- a/src/main/java/mealplanb/server/dto/member/GetRecommendedKcalRequest.java
+++ b/src/main/java/mealplanb/server/dto/member/GetRecommendedKcalRequest.java
@@ -10,9 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 @Setter
 @NoArgsConstructor
 public class GetRecommendedKcalRequest {
-    /**
-     * 사용자 목표 조회 (권장 칼로리 반환)
-     */
+    /** 사용자 목표 조회 (권장 칼로리 반환) */
     private double initialWeight;
     private double targetWeight;
 }

--- a/src/main/java/mealplanb/server/dto/member/GetRecommendedKcalResponse.java
+++ b/src/main/java/mealplanb/server/dto/member/GetRecommendedKcalResponse.java
@@ -6,8 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class GetRecommendedKcalResponse {
-    /**
-     * 사용자 목표 조회 (권장 칼로리 반환)
-     */
+    /** 사용자 목표 조회 (권장 칼로리 반환) */
     private int recommendedKcal;
 }

--- a/src/main/java/mealplanb/server/dto/member/PatchPlanRequest.java
+++ b/src/main/java/mealplanb/server/dto/member/PatchPlanRequest.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class PatchPlanRequest {
+    /** 사용자 목표 수정 */
 
     @NotNull(message = "initialWeight: {NotNull}")
     private double initialWeight;

--- a/src/main/java/mealplanb/server/dto/member/PatchPlanResponse.java
+++ b/src/main/java/mealplanb/server/dto/member/PatchPlanResponse.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class PatchPlanResponse {
+    /** 사용자 목표 수정 */
 
     private double initialWeight;
     private double targetWeight;

--- a/src/main/java/mealplanb/server/dto/statistic/GetKcalStatisticResponse.java
+++ b/src/main/java/mealplanb/server/dto/statistic/GetKcalStatisticResponse.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class GetKcalStatisticResponse {
+    /** 칼로리 일간, 월간, 주간 조회 */
 
     private String statisticType;
     private List<?> kcals;

--- a/src/main/java/mealplanb/server/dto/statistic/GetStatisticPlanResponse.java
+++ b/src/main/java/mealplanb/server/dto/statistic/GetStatisticPlanResponse.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class GetStatisticPlanResponse {
+    /** 통계페이지 상단 목표 조회 */
     private double initialWeight;
     private double targetWeight;
     private String dietType;

--- a/src/main/java/mealplanb/server/dto/weight/WeightRequest.java
+++ b/src/main/java/mealplanb/server/dto/weight/WeightRequest.java
@@ -12,9 +12,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 public class WeightRequest {
 
-    /**
-     * 체중 등록, 체중 수정
-     */
+    /** 체중 등록, 체중 수정 */
     @NotNull(message = "weight: {NotNull}")
     private double weight;
 

--- a/src/main/java/mealplanb/server/repository/FoodRepository.java
+++ b/src/main/java/mealplanb/server/repository/FoodRepository.java
@@ -25,11 +25,23 @@ public interface FoodRepository extends JpaRepository<Food, Long> {
             "AND f.kcal BETWEEN 0 AND ?1 " +
             "ORDER BY " +
             "CASE " +
-            "WHEN f.keyNutrient = ?2 THEN 1 " +
-            "WHEN f.keyNutrient = ?3 THEN 2 " +
-            "WHEN f.keyNutrient = ?4 THEN 3 " +
-            "ELSE 4 " +
-            "END, f.kcal DESC "+
-            "LIMIT 10")
+            "WHEN ?2 = '탄수화물' THEN f.carbohydrate " +
+            "WHEN ?2 = '단백질' THEN f.protein " +
+            "WHEN ?2 = '지방' THEN f.fat " +
+            "ELSE 0 " +
+            "END DESC, " +
+            "CASE " +
+            "WHEN ?3 = '탄수화물' THEN f.carbohydrate " +
+            "WHEN ?3 = '단백질' THEN f.protein " +
+            "WHEN ?3 = '지방' THEN f.fat " +
+            "ELSE 0 " +
+            "END DESC, " +
+            "CASE " +
+            "WHEN ?4 = '탄수화물' THEN f.carbohydrate " +
+            "WHEN ?4 = '단백질' THEN f.protein " +
+            "WHEN ?4 = '지방' THEN f.fat " +
+            "ELSE 0 " +
+            "END DESC, " +
+            "f.kcal DESC")
     Optional<List<Food>> getCheatDayFood(int remainingKcal, String lackingNutrient1, String lackingNutrient2, String lackingNutrient3, String category);
 }

--- a/src/main/java/mealplanb/server/repository/FoodRepository.java
+++ b/src/main/java/mealplanb/server/repository/FoodRepository.java
@@ -20,10 +20,15 @@ public interface FoodRepository extends JpaRepository<Food, Long> {
     Page<Food> getAutoComplete(@Param("query") String query, Pageable pageable);
 
     @Query("SELECT f FROM Food f " +
-            "WHERE f.keyNutrient = ?2 " +
-            "AND f.category = ?3 " +
+            "WHERE f.category = ?5 " +
             "AND f.kcal BETWEEN 0 AND ?1 " +
-            "ORDER BY f.kcal DESC "+
+            "ORDER BY " +
+            "CASE " +
+            "WHEN f.keyNutrient = ?2 THEN 1 " +
+            "WHEN f.keyNutrient = ?3 THEN 2 " +
+            "WHEN f.keyNutrient = ?4 THEN 3 " +
+            "ELSE 4 " +
+            "END, f.kcal DESC "+
             "LIMIT 10")
-    Optional<List<Food>> getCheatDayFood(int remainingKcal, String lackingNutrientName, String category);
+    Optional<List<Food>> getCheatDayFood(int remainingKcal, String lackingNutrient1, String lackingNutrient2, String lackingNutrient3, String category);
 }

--- a/src/main/java/mealplanb/server/service/ChatService.java
+++ b/src/main/java/mealplanb/server/service/ChatService.java
@@ -9,6 +9,7 @@ import mealplanb.server.dto.chat.GetFavoriteFoodResponse;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -23,8 +24,9 @@ public class ChatService {
      */
     public GetCheatDayFoodResponse getCheatDayFood(Long memberId, String category) {
         log.info("[ChatService.getCheatDayFood]");
-        int remainingKcal = memberService.calculateRemainingKcal(memberId);
-        String lackingNutrientName = memberService.getLackingNutrientName(memberId);
+        Map<String, Object> result = memberService.calculateRemainingKcalAndLackingNutrientName(memberId);
+        int remainingKcal = (int) result.get("remainingKcal");
+        String lackingNutrientName = (String) result.get("lackingNutrientName");
         List<cheatDayFoodInfo> cheatDayFood = foodService.getCheatDayFood(remainingKcal, lackingNutrientName, category);
         return new GetCheatDayFoodResponse(cheatDayFood);
     }

--- a/src/main/java/mealplanb/server/service/ChatService.java
+++ b/src/main/java/mealplanb/server/service/ChatService.java
@@ -32,8 +32,10 @@ public class ChatService {
             throw new ChatException(BaseExceptionResponseStatus.CHAT_CHEAT_DAY_LEFT_KCAL_NOT_EXIST);
         }
 
-        String lackingNutrientName = (String) result.get("lackingNutrientName");
-        List<cheatDayFoodInfo> cheatDayFood = foodService.getCheatDayFood(remainingKcal, lackingNutrientName, category);
+        String lackingNutrient1 = (String) result.get("lackingNutrient1");
+        String lackingNutrient2 = (String) result.get("lackingNutrient2");
+        String lackingNutrient3 = (String) result.get("lackingNutrient3");
+        List<cheatDayFoodInfo> cheatDayFood = foodService.getCheatDayFood(remainingKcal, lackingNutrient1, lackingNutrient2, lackingNutrient3, category);
         return new GetCheatDayFoodResponse(cheatDayFood);
     }
 

--- a/src/main/java/mealplanb/server/service/ChatService.java
+++ b/src/main/java/mealplanb/server/service/ChatService.java
@@ -2,6 +2,8 @@ package mealplanb.server.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import mealplanb.server.common.exception.ChatException;
+import mealplanb.server.common.response.status.BaseExceptionResponseStatus;
 import mealplanb.server.dto.chat.GetAmountSuggestionResponse;
 import mealplanb.server.dto.chat.GetCheatDayFoodResponse;
 import mealplanb.server.dto.chat.GetCheatDayFoodResponse.cheatDayFoodInfo;
@@ -26,6 +28,10 @@ public class ChatService {
         log.info("[ChatService.getCheatDayFood]");
         Map<String, Object> result = memberService.calculateRemainingKcalAndLackingNutrientName(memberId);
         int remainingKcal = (int) result.get("remainingKcal");
+        if (remainingKcal <= 0){
+            throw new ChatException(BaseExceptionResponseStatus.CHAT_CHEAT_DAY_LEFT_KCAL_NOT_EXIST);
+        }
+
         String lackingNutrientName = (String) result.get("lackingNutrientName");
         List<cheatDayFoodInfo> cheatDayFood = foodService.getCheatDayFood(remainingKcal, lackingNutrientName, category);
         return new GetCheatDayFoodResponse(cheatDayFood);

--- a/src/main/java/mealplanb/server/service/FavoriteMealComponentService.java
+++ b/src/main/java/mealplanb/server/service/FavoriteMealComponentService.java
@@ -6,7 +6,7 @@ import mealplanb.server.common.exception.MealException;
 import mealplanb.server.domain.Base.BaseStatus;
 import mealplanb.server.domain.FavoriteMeal;
 import mealplanb.server.domain.FavoriteMealComponent;
-import mealplanb.server.domain.Food;
+import mealplanb.server.domain.Food.Food;
 import mealplanb.server.dto.meal.GetMyMealResponse.FavoriteMealItem;
 import mealplanb.server.repository.FavoriteMealComponentRepository;
 import mealplanb.server.repository.FoodRepository;
@@ -43,7 +43,7 @@ public class FavoriteMealComponentService {
                     .orElseThrow(()-> new MealException(FAVORITE_MEAL_NOT_EXIST)); //해당 유저의 나의 식단이 존재하지 않습니다.
 
             for (FavoriteMealComponent component : favoriteMealComponentList) {
-                Food food = foodRepository.findByFoodId(component.getFood().getFoodId())
+                Food food = foodRepository.findByFoodIdAndStatus(component.getFood().getFoodId(), BaseStatus.A)
                         .orElseThrow(() -> new MealException(FAVORITE_MEAL_COMPONENT_NOT_EXIST)); // 나의 식단에 들어있는 식사가 없습니다.
 
                 // 식재료 량에 따라 칼로리 계산

--- a/src/main/java/mealplanb/server/service/FavoriteMealService.java
+++ b/src/main/java/mealplanb/server/service/FavoriteMealService.java
@@ -9,7 +9,7 @@ import mealplanb.server.common.response.status.BaseExceptionResponseStatus;
 import mealplanb.server.domain.Base.BaseStatus;
 import mealplanb.server.domain.FavoriteMeal;
 import mealplanb.server.domain.FavoriteMealComponent;
-import mealplanb.server.domain.Food;
+import mealplanb.server.domain.Food.Food;
 import mealplanb.server.domain.Member.Member;
 import mealplanb.server.dto.meal.GetMyMealResponse;
 import mealplanb.server.dto.meal.GetMyMealResponse.FavoriteMealItem;
@@ -61,7 +61,7 @@ public class FavoriteMealService {
         for (PostMyMealRequest.FoodItem foodItem : postMyMealRequest.getFoods()) {
             long foodId = foodItem.getFoodId();
             int quantity = foodItem.getQuantity();
-            Food food = foodRepository.findByFoodId(foodId)
+            Food food = foodRepository.findByFoodIdAndStatus(foodId, BaseStatus.A)
                     .orElseThrow(()-> new FoodException(FOOD_NOT_FOUND));
 
             FavoriteMealComponent favoriteMealComponent = FavoriteMealComponent.builder()

--- a/src/main/java/mealplanb/server/service/FoodService.java
+++ b/src/main/java/mealplanb/server/service/FoodService.java
@@ -153,7 +153,8 @@ public class FoodService {
                             offerCarbohydrate,
                             offerProtein,
                             offerFat,
-                            offer+ unitName));
+                            offer+ unitName,
+                            unitGram*offer));
         }
     }
 

--- a/src/main/java/mealplanb/server/service/FoodService.java
+++ b/src/main/java/mealplanb/server/service/FoodService.java
@@ -93,7 +93,7 @@ public class FoodService {
 
         // 사용자가 식품을 지울 권한이 있는지 검증
         if (!memberId.equals(food.getCreateMemberId())){
-            new FoodException(BaseExceptionResponseStatus.UNAUTHORIZED_ACCESS);
+            new FoodException(BaseExceptionResponseStatus.FOOD_UNAUTHORIZED_ACCESS);
         }
         food.setStatus(BaseStatus.D);
     }

--- a/src/main/java/mealplanb/server/service/FoodService.java
+++ b/src/main/java/mealplanb/server/service/FoodService.java
@@ -114,10 +114,10 @@ public class FoodService {
     /**
      * 채팅(치팅데이)
      */
-    public List<cheatDayFoodInfo> getCheatDayFood(int remainingKcal, String lackingNutrientName, String category) {
+    public List<cheatDayFoodInfo> getCheatDayFood(int remainingKcal, String lackingNutrient1, String lackingNutrient2, String lackingNutrient3, String category) {
         log.info("[FoodService.getCheatDayFood]");
 
-        Optional<List<Food>> cheatDayFoodOptional= foodRepository.getCheatDayFood(remainingKcal, lackingNutrientName, category);
+        Optional<List<Food>> cheatDayFoodOptional= foodRepository.getCheatDayFood(remainingKcal, lackingNutrient1, lackingNutrient2, lackingNutrient3, category);
         List<cheatDayFoodInfo> cheatDayFoodInfoList = new ArrayList<>(); // 반환값
 
         if (cheatDayFoodOptional.isPresent()) {

--- a/src/main/java/mealplanb/server/service/FoodService.java
+++ b/src/main/java/mealplanb/server/service/FoodService.java
@@ -172,7 +172,7 @@ public class FoodService {
         if (FoodManager.isContainsKey(food.getCategory())) { // 단위정보가 있는 음식의 경우
             foodUnit = FoodManager.getFoodUnit(food.getCategory());
         }else if (food.getCategory().equals("분식")){ //분식 카테고리는 음식이름이 카테고리
-            foodUnit = FoodManager.getFoodUnit(food.getCategory());
+            foodUnit = FoodManager.getFoodUnit(food.getName());
         }
         return foodUnit;
     }

--- a/src/main/java/mealplanb/server/service/FoodService.java
+++ b/src/main/java/mealplanb/server/service/FoodService.java
@@ -124,7 +124,7 @@ public class FoodService {
         if (cheatDayFoodOptional.isPresent()) {
             Map<String, Map<String, Object>> foodUnitMap = getFoodUnitMap(); // 치팅데이 단위 Map
 
-            if (foodUnitMap.containsKey(category)||category=="분식") { // 단위정보가 있는 음식의 경우
+            if (foodUnitMap.containsKey(category)||category.equals("분식")) { // 단위정보가 있는 음식의 경우
                 unitSuggestion(remainingKcal, category, cheatDayFoodOptional, cheatDayFoodInfoList, foodUnitMap);
             }else {
                 gramSuggestion(remainingKcal, cheatDayFoodOptional, cheatDayFoodInfoList);
@@ -145,7 +145,7 @@ public class FoodService {
         for (Food cheatDayFood : cheatDayFoodOptional.get()){
 
             // 분식의 경우 해당 음식의 이름으로 categoryInfo 를 갱신 (분식의 경우 categoryInfo 가 null 이었을것임)
-            if(cheatDayFood.getCategory()=="분식"){
+            if(cheatDayFood.getCategory().equals("분식")){
                 categoryInfo = foodUnitMap.get(cheatDayFood.getName());
             }
             int unitGram = (int) categoryInfo.get("unitGram");
@@ -170,7 +170,7 @@ public class FoodService {
         String name = cheatDayFood.getName();
 
         int offer;
-        if (unitName == "g"){
+        if (unitName.equals("g")){
             double gramKcal = cheatDayFood.getKcal() / unitGram;
             offer = (int) (remainingKcal / gramKcal);
             log.info("CheatDayFoodInfo : FoodId={}, Name={}, Offer={}{}, offerKcal= {}, (remainingKcal = {}, unitKcal = {})",

--- a/src/main/java/mealplanb/server/service/FoodService.java
+++ b/src/main/java/mealplanb/server/service/FoodService.java
@@ -61,8 +61,6 @@ public class FoodService {
         log.info("[FoodService.postNewFood]");
         Food newFood = new Food(memberId, postNewFoodRequest);
         foodRepository.save(newFood);
-        //todo: 코드 이렇게 길게 안하는 방법은 없을지...
-        //todo: 사실 PostNewFoodResponse랑 Food랑 status, updatedAt, createdAt 유무 차이라서 Food를 반환하는게 나을려나.
         return new PostNewFoodResponse(
                 newFood.getFoodId(),
                 newFood.getName(),

--- a/src/main/java/mealplanb/server/service/FoodService.java
+++ b/src/main/java/mealplanb/server/service/FoodService.java
@@ -140,9 +140,9 @@ public class FoodService {
         int unitGram = foodUnit.getUnitGram();
         String unitName = foodUnit.getUnitName();
         int offer = calculateOffer(remainingKcal, cheatDayFood, unitGram, unitName);
-        int offerCarbohydrate = (int) (cheatDayFood.getCarbohydrate() * (unitGram /100) * offer);
-        int offerProtein = (int) (cheatDayFood.getProtein() * (unitGram /100) * offer);
-        int offerFat = (int) (cheatDayFood.getFat() * (unitGram /100) * offer);
+        int offerCarbohydrate = (int) ((cheatDayFood.getCarbohydrate()/100)  * unitGram * offer);
+        int offerProtein = (int) ((cheatDayFood.getProtein()/100)  * unitGram * offer);
+        int offerFat = (int) ((cheatDayFood.getFat()/100)  * unitGram * offer);
         log.info("-----and offerCarbohydrate={}, offerProtein={}, offerFat={}",
                 offerCarbohydrate, offerProtein, offerFat);
 

--- a/src/main/java/mealplanb/server/service/MealService.java
+++ b/src/main/java/mealplanb/server/service/MealService.java
@@ -128,7 +128,7 @@ public class MealService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(()-> new MemberException(BaseExceptionResponseStatus.MEMBER_NOT_FOUND));
         if (!meal.getMember().equals(member)) {
-            throw new MealException(BaseExceptionResponseStatus.UNAUTHORIZED_ACCESS);
+            throw new MealException(BaseExceptionResponseStatus.MEAL_UNAUTHORIZED_ACCESS);
         }
 
         foodMealMappingTableService.postMealFood(member, meal, postMealFoodRequest.getFoods());

--- a/src/main/java/mealplanb/server/service/MemberService.java
+++ b/src/main/java/mealplanb/server/service/MemberService.java
@@ -24,7 +24,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.Period;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static mealplanb.server.common.response.status.BaseExceptionResponseStatus.*;
@@ -449,27 +451,6 @@ public class MemberService {
     }
 
     /**
-     * 유저의 남은 칼로리 계산 (for 치팅데이)
-     */
-    public int calculateRemainingKcal(Long memberId){
-        // 유저 정보 불러오기
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
-
-        // 오늘의 끼니 리스트 모아오기
-        Optional<List<Meal>> mealsOptional  = mealRepository.findByMember_MemberIdAndMealDateAndStatus(memberId, LocalDate.now(), BaseStatus.A);
-
-        // 타겟 칼로리
-        int targetKcal = member.getTargetKcal();
-        // 섭취한 총 칼로리
-        int kcal = calculateIntakeKcal(mealsOptional.get());
-        int remainingKcal = member.getTargetKcal() - calculateIntakeKcal(mealsOptional.get());// 해당 날짜의 남은 칼로리 계산
-        log.info("남은 칼로리 = {}", remainingKcal);
-
-        return  remainingKcal;
-    }
-
-    /**
      * 탄단지 그램수 계산
      */
     public int[] calculateNutrientGram(Member member){
@@ -487,16 +468,23 @@ public class MemberService {
     }
 
     /**
-     * 유저에게 가장 부족한 영양소 계산(for 치팅데이)
+     * 유저의 남은 칼로리 & 유저에게 가장 부족한 영양소 계산 (for 치팅데이)
      */
-    public String getLackingNutrientName(Long memberId){
+    public Map<String, Object> calculateRemainingKcalAndLackingNutrientName(Long memberId) {
         // 유저 정보 불러오기
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
-
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
         // 오늘의 끼니 리스트 모아오기
         Optional<List<Meal>> mealsOptional  = mealRepository.findByMember_MemberIdAndMealDateAndStatus(memberId, LocalDate.now(), BaseStatus.A);
 
+        //--------------------------------------------------
+
+        // [유저의 남은 칼로리 계산]
+        int remainingKcal = member.getTargetKcal() - calculateIntakeKcal(mealsOptional.get());// 해당 날짜의 남은 칼로리 계산
+        log.info("남은 칼로리 = {}", remainingKcal);
+
+        //--------------------------------------------------
+
+        // [유저에게 가장 부족한 영양소 계산]
         // 원래 섭취해야하는 탄,단,지
         int[] targetRatio = calculateNutrientGram(member);
         int targetCarbohydrate = targetRatio[0];
@@ -523,10 +511,29 @@ public class MemberService {
         } else {
             lackingNutrient = "지방";
         }
-
         log.info("남은 탄수화물/단백질/지방양 = {}/{}/{} => {}이 제일 부족", lackingCarbohydrate, lackingProtein, lackingFat, lackingNutrient);
 
-        return lackingNutrient;
+        //--------------------------------------------------
+        // 맵에 값을 담아 반환
+        Map<String, Object> result = new HashMap<>();
+        result.put("remainingKcal", remainingKcal);
+        result.put("lackingNutrientName", lackingNutrient);
+        return result;
+    }
+
+    /**
+     * 유저의 남은 칼로리 계산 (for 얼마나 먹을까요)
+     */
+    public int calculateRemainingKcal(Long memberId) {
+        // 유저 정보 불러오기
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+        // 오늘의 끼니 리스트 모아오기
+        Optional<List<Meal>> mealsOptional = mealRepository.findByMember_MemberIdAndMealDateAndStatus(memberId, LocalDate.now(), BaseStatus.A);
+
+        // [유저의 남은 칼로리 계산]
+        int remainingKcal = member.getTargetKcal() - calculateIntakeKcal(mealsOptional.get());// 해당 날짜의 남은 칼로리 계산
+        log.info("남은 칼로리 = {}", remainingKcal);
+        return remainingKcal;
     }
 
     /** 해당 id를 가진 member가 존재하는지 여부 파악, 없으면 MEMBER_NOT_FOUND 에러*/


### PR DESCRIPTION
## 개요
- `Meal-136-BE-채팅(치팅데이)api` 코멘트 관련 수정사항 pr입니다.
- https://github.com/KUIT2-MealplanB/mealplanb_server/pull/144#issue-2130641605

## 작업사항
- 코멘트 관련 수정 사항
   - dto 주석 없는 부분 추가
   - 문자열 비교 == 에서 .equals로 수정
   - 칼로리 계산 메소드 부분 논의한 부분 수정 ([해당 코멘트 보러가기](https://github.com/KUIT2-MealplanB/mealplanb_server/pull/144/files/fe9378b2218a4936db219cc1695f25d236dcbc50#r1488775493)) => **특히 이 부분 이렇게 수정하면  될 지 확인 부탁드립니다.**

- 개인적인 수정 사항
   - todo 주석 제거 ( 수정이 필요없을 것 같아 삭제)
   - response에 quantity 추가 (채팅을 통한 끼니 등록을 위해)
      <img width="862" alt="image" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/84059402/dc780353-8ee2-4e98-b6ec-35206ad9f2e6">

   - 정수/정수(몫만 계산됨)로 계산이 잘못되고 있던 부분 수정
   - ChatException & ChatExceptionControllerAdvice 생성
   - 사용자의 잔여 칼로리가 없을 경우 예외처리
      <img width="636" alt="image" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/84059402/103b2417-4eaf-41e6-a15e-c861409b6501">

   - 치팅데이 로직 변경(최대한 부족한 영양소가 많이 든 음식 추천)
       -  (분식의 경우 현재 주영양소가 탄수화물 밖에 업는데, 이경우 지방이 가장 부족한 사용자가 치팅데이 음식 추천을 요구할 시, 가장 부족한 영양소가 주 영양소에서만 음식을 추천해주기 때문에 분식에서는 아무음식도 추천되지 않는 문제 해결)

- develop pull 받아서 실행하려고 했더니, 오류가 나서 관련 오류를 해결하였습니다.
   - ExceptionResponse 중복오류 해결 (UNAUTHORIZED_ACCESS 2개 존재 => FOOD_UNAUTHORIZED_ACCESS/ MEAL_UNAUTHORIZED_ACCESS 로 분리)
   -  Food 디렉토리 위치 이동 수정
   - foodRepository.findById -> foodRepository.findByFoodIdAndStatus로 수정

## 주의사항
- 