### PR TITLE
Fix: Meal-139-BE-채팅(인기있는) / Meal-138-BE-채팅(자주먹은)

### DIFF
--- a/src/main/java/mealplanb/server/dto/chat/GetAmountSuggestionResponse.java
+++ b/src/main/java/mealplanb/server/dto/chat/GetAmountSuggestionResponse.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class GetAmountSuggestionResponse {
+    /** 얼마나 먹을까요 */
     private String foodName;
     private String offer;
     private int offerKcal;

--- a/src/main/java/mealplanb/server/dto/chat/GetAmountSuggestionResponse.java
+++ b/src/main/java/mealplanb/server/dto/chat/GetAmountSuggestionResponse.java
@@ -9,5 +9,8 @@ public class GetAmountSuggestionResponse {
     private String foodName;
     private String offer;
     private int offerKcal;
+    private int offerCarbohydrate;
+    private int offerProtein;
+    private int offerFat;
     private int remainingKcal;
 }

--- a/src/main/java/mealplanb/server/dto/chat/GetCheatDayFoodResponse.java
+++ b/src/main/java/mealplanb/server/dto/chat/GetCheatDayFoodResponse.java
@@ -16,10 +16,10 @@ public class GetCheatDayFoodResponse {
     public static class cheatDayFoodInfo {
         private long foodId;
         private String name;
-        private int carbohydrate;
-        private int protein;
-        private int fat;
         private String offer;
         private int quantity;
+        private int offerCarbohydrate;
+        private int offerProtein;
+        private int offerFat;
     }
 }

--- a/src/main/java/mealplanb/server/dto/chat/GetFavoriteFoodResponse.java
+++ b/src/main/java/mealplanb/server/dto/chat/GetFavoriteFoodResponse.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class GetFavoriteFoodResponse {
+    /** 채팅(자주먹은), 채팅(인기있는) */
     private long foodId;
     private String name;
     private String offer;

--- a/src/main/java/mealplanb/server/dto/chat/GetFavoriteFoodResponse.java
+++ b/src/main/java/mealplanb/server/dto/chat/GetFavoriteFoodResponse.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public class GetFavoriteFoodResponse {
     private long foodId;
     private String name;
-    private int carbohydrate;
-    private int protein;
-    private int fat;
+    private String offer;
+    private int offerCarbohydrate;
+    private int offerProtein;
+    private int offerFat;
 }

--- a/src/main/java/mealplanb/server/service/ChatService.java
+++ b/src/main/java/mealplanb/server/service/ChatService.java
@@ -34,7 +34,9 @@ public class ChatService {
      */
     public GetFavoriteFoodResponse getMyFavoriteFood(Long memberId) {
         log.info("[ChatService.getMyFavoriteFood]");
-        return foodMealMappingTableService.getMyFavoriteFood(memberId);
+        long myFavoriteFood = foodMealMappingTableService.getMyFavoriteFoodId(memberId);
+        GetAmountSuggestionResponse amountSuggestion = getAmountSuggestion(memberId, myFavoriteFood);
+        return new GetFavoriteFoodResponse(myFavoriteFood, amountSuggestion.getFoodName(), amountSuggestion.getOffer(), amountSuggestion.getOfferCarbohydrate(), amountSuggestion.getOfferProtein(), amountSuggestion.getOfferFat());
     }
 
     /**
@@ -43,7 +45,9 @@ public class ChatService {
     public GetFavoriteFoodResponse getCommunityFavoriteFood(Long memberId) {
         log.info("[ChatService.getCommunityFavoriteFood]");
         memberService.checkMemberExist(memberId);
-        return foodMealMappingTableService.getCommunityFavoriteFood();
+        long communityFavoriteFoodId = foodMealMappingTableService.getCommunityFavoriteFoodId();
+        GetAmountSuggestionResponse amountSuggestion = getAmountSuggestion(memberId, communityFavoriteFoodId);
+        return new GetFavoriteFoodResponse(communityFavoriteFoodId, amountSuggestion.getFoodName(), amountSuggestion.getOffer(), amountSuggestion.getOfferCarbohydrate(), amountSuggestion.getOfferProtein(), amountSuggestion.getOfferFat());
     }
 
     /**

--- a/src/main/java/mealplanb/server/service/ChatService.java
+++ b/src/main/java/mealplanb/server/service/ChatService.java
@@ -44,9 +44,9 @@ public class ChatService {
      */
     public GetFavoriteFoodResponse getMyFavoriteFood(Long memberId) {
         log.info("[ChatService.getMyFavoriteFood]");
-        long myFavoriteFood = foodMealMappingTableService.getMyFavoriteFoodId(memberId);
-        GetAmountSuggestionResponse amountSuggestion = getAmountSuggestion(memberId, myFavoriteFood);
-        return new GetFavoriteFoodResponse(myFavoriteFood, amountSuggestion.getFoodName(), amountSuggestion.getOffer(), amountSuggestion.getOfferCarbohydrate(), amountSuggestion.getOfferProtein(), amountSuggestion.getOfferFat());
+        long myFavoriteFoodId = foodMealMappingTableService.getMyFavoriteFoodId(memberId);
+        GetAmountSuggestionResponse amountSuggestion = getAmountSuggestion(memberId, myFavoriteFoodId);
+        return new GetFavoriteFoodResponse(myFavoriteFoodId, amountSuggestion.getFoodName(), amountSuggestion.getOffer(), amountSuggestion.getOfferCarbohydrate(), amountSuggestion.getOfferProtein(), amountSuggestion.getOfferFat());
     }
 
     /**

--- a/src/main/java/mealplanb/server/service/FoodMealMappingTableService.java
+++ b/src/main/java/mealplanb/server/service/FoodMealMappingTableService.java
@@ -113,22 +113,23 @@ public class FoodMealMappingTableService {
     /**
      * 채팅(자주먹는)
      */
-    public GetFavoriteFoodResponse getMyFavoriteFood(Long memberId) {
+    public long getMyFavoriteFoodId(Long memberId) {
         log.info("[FoodMealMappingTableService.getMyFavoriteFood]");
         Long mostEatenFoodId = foodMealMappingTableRepository.findMostEatenFoodIdByUserId(memberId);
         Food myFavoriteFood = foodRepository.findByFoodIdAndStatus(mostEatenFoodId, BaseStatus.A)
                 .orElseThrow(() -> new FoodException(BaseExceptionResponseStatus.FOOD_NOT_FOUND));
-        return new GetFavoriteFoodResponse(myFavoriteFood.getFoodId(), myFavoriteFood.getName(), (int) myFavoriteFood.getCarbohydrate(), (int) myFavoriteFood.getProtein(), (int) myFavoriteFood.getFat());
+        return myFavoriteFood.getFoodId();
     }
 
     /**
      * 채팅(인기있는)
      */
-    public GetFavoriteFoodResponse getCommunityFavoriteFood() {
+    public long getCommunityFavoriteFoodId() {
         log.info("[FoodMealMappingTableService.getCommunityFavoriteFood]");
         Long mostEatenFoodId = foodMealMappingTableRepository.findMostEatenFoodId();
         Food communityFavoriteFood = foodRepository.findByFoodIdAndStatus(mostEatenFoodId, BaseStatus.A)
                 .orElseThrow(() -> new FoodException(BaseExceptionResponseStatus.FOOD_NOT_FOUND));
-        return new GetFavoriteFoodResponse(communityFavoriteFood.getFoodId(), communityFavoriteFood.getName(), (int) communityFavoriteFood.getCarbohydrate(), (int) communityFavoriteFood.getProtein(), (int) communityFavoriteFood.getFat());
+
+        return communityFavoriteFood.getFoodId();
     }
 }

--- a/src/main/java/mealplanb/server/service/FoodService.java
+++ b/src/main/java/mealplanb/server/service/FoodService.java
@@ -188,7 +188,10 @@ public class FoodService {
         FoodUnit foodUnit = getFoodUnit(food);
         int offer = calculateOffer(remainingKcal, food, foodUnit.getUnitGram(), foodUnit.getUnitName());
         int offerKcal = (int) (foodUnit.getUnitGram() * (food.getKcal() /100) * offer);
+        int offerCarbohydrate = (int) (foodUnit.getUnitGram() * (food.getCarbohydrate() /100) * offer);
+        int offerProtein = (int) (foodUnit.getUnitGram() * (food.getProtein() /100) * offer);
+        int offerFat = (int) (foodUnit.getUnitGram() * (food.getFat() /100) * offer);
 
-        return new GetAmountSuggestionResponse(food.getName(), offer+foodUnit.getUnitName(), offerKcal, remainingKcal);
+        return new GetAmountSuggestionResponse(food.getName(), offer+foodUnit.getUnitName(), offerKcal, offerCarbohydrate, offerProtein, offerFat,  remainingKcal);
     }
 }

--- a/src/main/java/mealplanb/server/service/FoodService.java
+++ b/src/main/java/mealplanb/server/service/FoodService.java
@@ -150,10 +150,10 @@ public class FoodService {
             cheatDayFoodInfoList.add( new cheatDayFoodInfo(
                             cheatDayFood.getFoodId(),
                             cheatDayFood.getName(),
+                        offer+unitName,
                             offerCarbohydrate,
                             offerProtein,
                             offerFat,
-                            offer+ unitName,
                             unitGram*offer));
         }
     }


### PR DESCRIPTION
## 개요
- 채팅(인기있는), 채팅(자주먹은)에 제공량 및 제공량에 맞는 탄단지 값 response에 추가

## 작업사항
-  채팅(자주먹은)이랑 채팅(인기있는)도 제공양이 필요하게 되어서 response dto를 수정하였습니다.
- https://www.notion.so/0216-4f7fb7a460674b46ac8a131957f65bae

- 채팅(인기있는) postman 결과 (offer, offer_carbohydrate, offer_protein, offer_fat이 추가됨)
  <img width="628" alt="image" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/84059402/b6ad89b1-f658-46b4-acc6-5d03005ca065">

- 채팅(자주먹은) postman 결과 (offer, offer_carbohydrate, offer_protein, offer_fat이 추가됨)
  <img width="617" alt="image" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/84059402/2f35fd64-7425-487d-8cad-005872ac5e04">

## 주의사항

