### PR TITLE
Feat: MEAL-122-BE-나의식단 식사 리스트 조회 api

### DIFF
--- a/src/main/java/mealplanb/server/controller/FavoriteMealController.java
+++ b/src/main/java/mealplanb/server/controller/FavoriteMealController.java
@@ -4,9 +4,9 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mealplanb.server.common.response.BaseResponse;
+import mealplanb.server.dto.meal.GetMyMealListResponse;
 import mealplanb.server.dto.meal.GetMyMealResponse;
 import mealplanb.server.dto.meal.PostMyMealRequest;
-import mealplanb.server.service.FavoriteMealComponentService;
 import mealplanb.server.service.FavoriteMealService;
 import mealplanb.server.util.jwt.JwtProvider;
 import org.springframework.web.bind.annotation.*;
@@ -19,7 +19,6 @@ public class FavoriteMealController {
 
     private final JwtProvider jwtProvider;
     private final FavoriteMealService favoriteMealService;
-    private final FavoriteMealComponentService favoriteMealComponentService;
 
     /**
      * 나의 식단 등록
@@ -55,4 +54,16 @@ public class FavoriteMealController {
         favoriteMealService.deleteMyMeal(memberId, favoriteMealId);
         return new BaseResponse<>(null);
     }
+
+    /**
+     * 나의 식단 선택해서 식사 리스트 조회하기
+     */
+    @GetMapping("/{favoriteMealId}")
+    public BaseResponse<GetMyMealListResponse> getMyMealList(@RequestHeader("Authorization") String authorization,
+                                                             @PathVariable Long favoriteMealId){
+        log.info("[FavoriteMealController.getMyMealList]");
+        Long memberId = jwtProvider.extractIdFromHeader(authorization);
+        return new BaseResponse<>(favoriteMealService.getMyMealList(memberId, favoriteMealId));
+    }
+
 }

--- a/src/main/java/mealplanb/server/dto/meal/GetMyMealListResponse.java
+++ b/src/main/java/mealplanb/server/dto/meal/GetMyMealListResponse.java
@@ -1,0 +1,34 @@
+package mealplanb.server.dto.meal;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class GetMyMealListResponse {
+    /**
+     * 나의 식단 선택해서 식사 리스트 조회하기
+     */
+    private List<GetMyMealItem> myMealItemList;
+
+    @Getter
+    @NoArgsConstructor
+    public static class GetMyMealItem{
+        private long foodId;
+        private String foodName;
+        private int quantity;
+        private int kcal;
+
+        public GetMyMealItem(long foodId, String foodName, int quantity, int kcal){
+            this.foodId = foodId;
+            this.foodName = foodName;
+            this.quantity = quantity;
+            this.kcal = kcal;
+        }
+    }
+
+
+}

--- a/src/main/java/mealplanb/server/repository/FavoriteMealComponentRepository.java
+++ b/src/main/java/mealplanb/server/repository/FavoriteMealComponentRepository.java
@@ -9,5 +9,4 @@ import java.util.Optional;
 
 public interface FavoriteMealComponentRepository extends JpaRepository<FavoriteMealComponent, Long> {
     Optional<List<FavoriteMealComponent>> findByFavoriteMeal_FavoriteMealIdAndStatus(Long favoriteMealId, BaseStatus A);
-    Optional<FavoriteMealComponent> findOneByFavoriteMeal_FavoriteMealIdAndStatus(Long favoriteMealId, BaseStatus A);
 }

--- a/src/main/java/mealplanb/server/repository/FavoriteMealRepository.java
+++ b/src/main/java/mealplanb/server/repository/FavoriteMealRepository.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 public interface FavoriteMealRepository extends JpaRepository<FavoriteMeal, Long> {
 
     boolean existsByFavoriteMealNameAndStatus(String favoriteMealName, BaseStatus A);
+    boolean existsByFavoriteMealIdAndStatus(Long favoriteMealId, BaseStatus A);
     Optional<List<FavoriteMeal>> findByMember_MemberIdAndStatus(Long memberId, BaseStatus A);
     Optional<FavoriteMeal> findByMember_MemberIdAndFavoriteMealIdAndStatus(Long memberId, Long favoriteMealID, BaseStatus A);
 }

--- a/src/main/java/mealplanb/server/service/FavoriteMealComponentService.java
+++ b/src/main/java/mealplanb/server/service/FavoriteMealComponentService.java
@@ -8,6 +8,7 @@ import mealplanb.server.domain.Base.BaseStatus;
 import mealplanb.server.domain.FavoriteMeal;
 import mealplanb.server.domain.FavoriteMealComponent;
 import mealplanb.server.domain.Food.Food;
+import mealplanb.server.dto.meal.GetMyMealListResponse;
 import mealplanb.server.dto.meal.GetMyMealResponse.FavoriteMealItem;
 import mealplanb.server.dto.meal.PostMyMealRequest;
 import mealplanb.server.repository.FavoriteMealComponentRepository;
@@ -24,6 +25,7 @@ import static mealplanb.server.common.response.status.BaseExceptionResponseStatu
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FavoriteMealComponentService {
 
     private final FoodRepository foodRepository;
@@ -55,7 +57,6 @@ public class FavoriteMealComponentService {
     /**
      * 나의 식단 조회
      */
-    @Transactional(readOnly = true)
     public List<FavoriteMealItem> getFavoriteMealComponentList(List<FavoriteMeal> favoriteMeal){
         log.info("[FavoriteMealComponentService.getFavoriteMealComponentList]");
         List<FavoriteMealItem> mealItemList = new ArrayList<>();
@@ -98,4 +99,35 @@ public class FavoriteMealComponentService {
             component.updateStatus(BaseStatus.D);
         }
     }
+
+    /**
+     * 나의 식단 선택해서 식사 리스트 조회하기
+     */
+    public List<GetMyMealListResponse.GetMyMealItem> getMyMealList(Long favoriteMealId){
+        log.info("[FavoriteMealComponentService.getMyMealList]");
+        List<GetMyMealListResponse.GetMyMealItem> myMealItemList = new ArrayList<>();
+
+        List<FavoriteMealComponent> favoriteMealComponentList = favoriteMealComponentRepository.findByFavoriteMeal_FavoriteMealIdAndStatus(favoriteMealId,BaseStatus.A)
+                .orElseThrow(()->new MealException(FAVORITE_MEAL_COMPONENT_NOT_EXIST));
+
+        for(FavoriteMealComponent component : favoriteMealComponentList){
+            int kcal = 0;
+            long foodId = component.getFood().getFoodId();
+            Food food = foodRepository.findByFoodId(foodId)
+                    .orElseThrow(() -> new MealException(FAVORITE_MEAL_COMPONENT_NOT_EXIST)); // 나의 식단에 들어있는 식사가 없습니다.
+
+            // 식재료 량에 따라 칼로리 계산
+            kcal = (int)(food.getKcal() * component.getQuantity() / 100);
+
+            GetMyMealListResponse.GetMyMealItem getMyMealItem= new GetMyMealListResponse.GetMyMealItem(
+                    foodId,
+                    food.getName(),
+                    component.getQuantity(),
+                    kcal
+            );
+            myMealItemList.add(getMyMealItem);
+        }
+        return myMealItemList;
+    }
+
 }

--- a/src/main/java/mealplanb/server/service/FavoriteMealComponentService.java
+++ b/src/main/java/mealplanb/server/service/FavoriteMealComponentService.java
@@ -114,7 +114,7 @@ public class FavoriteMealComponentService {
             int kcal = 0;
             long foodId = component.getFood().getFoodId();
             Food food = foodRepository.findByFoodId(foodId)
-                    .orElseThrow(() -> new MealException(FAVORITE_MEAL_COMPONENT_NOT_EXIST)); // 나의 식단에 들어있는 식사가 없습니다.
+                    .orElseThrow(() -> new MealException(FOOD_NOT_FOUND));
 
             // 식재료 량에 따라 칼로리 계산
             kcal = (int)(food.getKcal() * component.getQuantity() / 100);


### PR DESCRIPTION
## 개요
- 나의 식단에서 식단을 선택하면 바로 식사 등록하는 페이지로 넘어가는데, 그때 필요한 식사 이름, 양, 칼로리를 보여주기 위해 필요한 api 입니다.

## 작업사항
- GetMyMealListResponse 를 작성하였습니다. 구체적인 response 는 [api 명세서](https://ultra-sound-723.notion.site/my-meal-favorite_meal_id-c923b54bd1024cc6ac378c4ecc44770e?pvs=4) 에서 확인하실 수 있습니다.
- @Transactional 의 기본값이 readOnly = false 상태인데, 제일 바깥 클래스 상단에 @Transactional (readOnly = true) 라고 선언하고 필요한 메소드에만 @Transactional 을 붙여서 수정하였습니다! 다른 특이사항은 없습니다.

## 주의사항
```
http://localhost:9000/my-meal/7
```
<img width="746" alt="스크린샷 2024-02-17 오후 3 14 02" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/122519994/6574afc4-f9d5-40c6-a9fb-90afd7198622">

- postman 테스트 결과입니다.