### PR TITLE
Feat:  Meal-138,139-BE-채팅(인기있는,자주먹는) api response에 offerQuantity 추가

### DIFF
--- a/src/main/java/mealplanb/server/controller/ChatController.java
+++ b/src/main/java/mealplanb/server/controller/ChatController.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import mealplanb.server.common.response.BaseResponse;
 import mealplanb.server.dto.chat.GetAmountSuggestionResponse;
 import mealplanb.server.dto.chat.GetCheatDayFoodResponse;
-import mealplanb.server.dto.chat.GetFavoriteFoodResponse;
+import mealplanb.server.dto.chat.GetMostEatenFoodResponse;
 import mealplanb.server.service.ChatService;
 import mealplanb.server.util.jwt.JwtProvider;
 import org.springframework.web.bind.annotation.*;
@@ -33,7 +33,7 @@ public class ChatController {
      * 채팅(자주먹는)
      */
     @GetMapping("/my-favorite")
-    public BaseResponse<GetFavoriteFoodResponse> getMyFavoriteFood(@RequestHeader("Authorization") String authorization){
+    public BaseResponse<GetMostEatenFoodResponse> getMyFavoriteFood(@RequestHeader("Authorization") String authorization){
         log.info("[ChatController.getMyFavoriteFood]");
         Long memberId = jwtProvider.extractIdFromHeader(authorization);
         return new BaseResponse<>(chatService.getMyFavoriteFood(memberId));
@@ -43,7 +43,7 @@ public class ChatController {
      * 채팅(인기있는)
      */
     @GetMapping("/community-favorite")
-    public BaseResponse<GetFavoriteFoodResponse> getCommunityFavoriteFood(@RequestHeader(value = "Authorization") String authorization){
+    public BaseResponse<GetMostEatenFoodResponse> getCommunityFavoriteFood(@RequestHeader(value = "Authorization") String authorization){
         log.info("[ChatController.getCommunityFavoriteFood]");
         Long memberId = jwtProvider.extractIdFromHeader(authorization);
         return new BaseResponse<>(chatService.getCommunityFavoriteFood(memberId));

--- a/src/main/java/mealplanb/server/dto/chat/GetAmountSuggestionResponse.java
+++ b/src/main/java/mealplanb/server/dto/chat/GetAmountSuggestionResponse.java
@@ -10,6 +10,7 @@ public class GetAmountSuggestionResponse {
     private String foodName;
     private String offer;
     private int offerKcal;
+    private int offerQuantity;
     private int offerCarbohydrate;
     private int offerProtein;
     private int offerFat;

--- a/src/main/java/mealplanb/server/dto/chat/GetMostEatenFoodResponse.java
+++ b/src/main/java/mealplanb/server/dto/chat/GetMostEatenFoodResponse.java
@@ -5,11 +5,12 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class GetFavoriteFoodResponse {
-    /** 채팅(자주먹은), 채팅(인기있는) */
+public class GetMostEatenFoodResponse {
+    /** 채팅(자주먹은), 채팅(인기있는)*/
     private long foodId;
     private String name;
     private String offer;
+    private int offerQuantity;
     private int offerCarbohydrate;
     private int offerProtein;
     private int offerFat;

--- a/src/main/java/mealplanb/server/service/ChatService.java
+++ b/src/main/java/mealplanb/server/service/ChatService.java
@@ -7,7 +7,7 @@ import mealplanb.server.common.response.status.BaseExceptionResponseStatus;
 import mealplanb.server.dto.chat.GetAmountSuggestionResponse;
 import mealplanb.server.dto.chat.GetCheatDayFoodResponse;
 import mealplanb.server.dto.chat.GetCheatDayFoodResponse.cheatDayFoodInfo;
-import mealplanb.server.dto.chat.GetFavoriteFoodResponse;
+import mealplanb.server.dto.chat.GetMostEatenFoodResponse;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -42,22 +42,22 @@ public class ChatService {
     /**
      * 채팅(자주먹는)
      */
-    public GetFavoriteFoodResponse getMyFavoriteFood(Long memberId) {
+    public GetMostEatenFoodResponse getMyFavoriteFood(Long memberId) {
         log.info("[ChatService.getMyFavoriteFood]");
         long myFavoriteFoodId = foodMealMappingTableService.getMyFavoriteFoodId(memberId);
         GetAmountSuggestionResponse amountSuggestion = getAmountSuggestion(memberId, myFavoriteFoodId);
-        return new GetFavoriteFoodResponse(myFavoriteFoodId, amountSuggestion.getFoodName(), amountSuggestion.getOffer(), amountSuggestion.getOfferCarbohydrate(), amountSuggestion.getOfferProtein(), amountSuggestion.getOfferFat());
+        return new GetMostEatenFoodResponse(myFavoriteFoodId, amountSuggestion.getFoodName(), amountSuggestion.getOffer(), amountSuggestion.getOfferQuantity(), amountSuggestion.getOfferCarbohydrate(), amountSuggestion.getOfferProtein(), amountSuggestion.getOfferFat());
     }
 
     /**
      * 채팅(인기있는)
      */
-    public GetFavoriteFoodResponse getCommunityFavoriteFood(Long memberId) {
+    public GetMostEatenFoodResponse getCommunityFavoriteFood(Long memberId) {
         log.info("[ChatService.getCommunityFavoriteFood]");
         memberService.checkMemberExist(memberId);
         long communityFavoriteFoodId = foodMealMappingTableService.getCommunityFavoriteFoodId();
         GetAmountSuggestionResponse amountSuggestion = getAmountSuggestion(memberId, communityFavoriteFoodId);
-        return new GetFavoriteFoodResponse(communityFavoriteFoodId, amountSuggestion.getFoodName(), amountSuggestion.getOffer(), amountSuggestion.getOfferCarbohydrate(), amountSuggestion.getOfferProtein(), amountSuggestion.getOfferFat());
+        return new GetMostEatenFoodResponse(communityFavoriteFoodId, amountSuggestion.getFoodName(), amountSuggestion.getOffer(), amountSuggestion.getOfferQuantity(), amountSuggestion.getOfferCarbohydrate(), amountSuggestion.getOfferProtein(), amountSuggestion.getOfferFat());
     }
 
     /**

--- a/src/main/java/mealplanb/server/service/FoodMealMappingTableService.java
+++ b/src/main/java/mealplanb/server/service/FoodMealMappingTableService.java
@@ -8,7 +8,6 @@ import mealplanb.server.domain.Food.Food;
 import mealplanb.server.common.exception.FoodException;
 import mealplanb.server.common.response.status.BaseExceptionResponseStatus;
 import mealplanb.server.domain.FoodMealMappingTable;
-import mealplanb.server.dto.chat.GetFavoriteFoodResponse;
 import mealplanb.server.dto.meal.GetMealFoodResponse.FoodInfo;
 import mealplanb.server.domain.Meal.Meal;
 import mealplanb.server.domain.Member.Member;

--- a/src/main/java/mealplanb/server/service/FoodService.java
+++ b/src/main/java/mealplanb/server/service/FoodService.java
@@ -187,10 +187,11 @@ public class FoodService {
         FoodUnit foodUnit = getFoodUnit(food);
         int offer = calculateOffer(remainingKcal, food, foodUnit.getUnitGram(), foodUnit.getUnitName());
         int offerKcal = (int) (foodUnit.getUnitGram() * (food.getKcal() /100) * offer);
+        int offerQuantity = foodUnit.getUnitGram() * offer;
         int offerCarbohydrate = (int) (foodUnit.getUnitGram() * (food.getCarbohydrate() /100) * offer);
         int offerProtein = (int) (foodUnit.getUnitGram() * (food.getProtein() /100) * offer);
         int offerFat = (int) (foodUnit.getUnitGram() * (food.getFat() /100) * offer);
 
-        return new GetAmountSuggestionResponse(food.getName(), offer+foodUnit.getUnitName(), offerKcal, offerCarbohydrate, offerProtein, offerFat,  remainingKcal);
+        return new GetAmountSuggestionResponse(food.getName(), offer+foodUnit.getUnitName(), offerKcal, offerQuantity ,offerCarbohydrate, offerProtein, offerFat,  remainingKcal);
     }
 }


### PR DESCRIPTION
## 개요
- GetMostEatenFoodResponse의 offerQuantity, foodId를 이용해서 채팅을 통한 끼니 등록을 할 수 있도록 채팅(인기있는,자주먹는) api response에 **offerQuantity** (추천하는 양의 gram수) 추가하였습니다.

## 작업사항
- 치팅데이를 통해 추천받은 음식만 채팅을 통한 끼니 등록이 가능한 줄 알았는데, 치팅데이, 채팅(인기있는,자주먹는) 이 3가지 기능 모두 음식과, 사용자에게 남은 칼로리에 맞는 제공양을 추천해주고  그 정보를 바탕으로 채팅을 통한 끼니 등록이 가능하다고 합니다. => 따라서 채팅(인기있는,자주먹는) api response에 offerQuantity (추천하는 양의 gram수) 추가하였습니다.
- 관련 질문 :  https://www.notion.so/0216-4f7fb7a460674b46ac8a131957f65bae 12번 질문 참조

## 주의사항
- 채팅(인기있는,자주먹는) api response인 GetFavoriteFoodResponse => GetMostEatenFoodResponse로 이름 변경하였습니다.
- (이유: 즐겨찾기한 식품 조회 response인 GetFavoriteFoodResponse와 이름이 겹쳐서)
