### PR TITLE
Feat: Meal-141-BE-등록식단모아보기api

### DIFF
--- a/src/main/java/mealplanb/server/controller/ChatController.java
+++ b/src/main/java/mealplanb/server/controller/ChatController.java
@@ -6,10 +6,13 @@ import mealplanb.server.common.response.BaseResponse;
 import mealplanb.server.dto.chat.GetAmountSuggestionResponse;
 import mealplanb.server.dto.chat.GetCheatDayFoodResponse;
 import mealplanb.server.dto.chat.GetFavoriteFoodResponse;
+import mealplanb.server.dto.chat.GetMealSuggestedFoodResponse;
 import mealplanb.server.dto.meal.PostMealFoodRequest;
 import mealplanb.server.service.ChatService;
 import mealplanb.server.util.jwt.JwtProvider;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static mealplanb.server.dto.meal.PostMealFoodRequest.*;
 
@@ -74,4 +77,15 @@ public class ChatController {
         chatService.postMealSuggestedFood(memberId, food);
         return new BaseResponse<>(null);
     }
+
+    /**
+     * 채팅을 통해 추천받은 끼니 조회 (등록식단 모아보기)
+     */
+    @GetMapping("/meal")
+    public BaseResponse<List<GetMealSuggestedFoodResponse>> getMealSuggestedFood(@RequestHeader("Authorization") String authorization){
+        log.info("[ChatController.getMealSuggestedFood]");
+        Long memberId = jwtProvider.extractIdFromHeader(authorization);
+        return new BaseResponse<>(chatService.getMealSuggestedFood(memberId));
+    }
+
 }

--- a/src/main/java/mealplanb/server/dto/chat/GetMealSuggestedFoodResponse.java
+++ b/src/main/java/mealplanb/server/dto/chat/GetMealSuggestedFoodResponse.java
@@ -1,0 +1,16 @@
+package mealplanb.server.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetMealSuggestedFoodResponse {
+    /** 채팅을 통해 추천받은 끼니 조회 (등록식단 모아보기) */
+    private String date;
+    private String mealType;
+    private String name;
+    private int offerCarbohydrate;
+    private int offerProtein;
+    private int offerFat;
+}

--- a/src/main/java/mealplanb/server/repository/FoodMealMappingTableRepository.java
+++ b/src/main/java/mealplanb/server/repository/FoodMealMappingTableRepository.java
@@ -2,6 +2,7 @@ package mealplanb.server.repository;
 
 import mealplanb.server.domain.Base.BaseStatus;
 import mealplanb.server.domain.FoodMealMappingTable;
+import mealplanb.server.domain.Meal.Meal;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -28,4 +29,11 @@ public interface FoodMealMappingTableRepository extends JpaRepository<FoodMealMa
             "ORDER BY COUNT(*) DESC "+
             "LIMIT 1", nativeQuery = true)
     Long findMostEatenFoodId();
+
+    @Query(value = "SELECT * " +
+            "FROM food_meal_mapping_table fm " +
+            "WHERE fm.member_id = :memberId AND fm.status = 'A' "+
+            "AND fm.is_recommended = true", nativeQuery = true)
+    Optional<List<FoodMealMappingTable>> findAllMealSuggestedFood(@Param("memberId") Long memberId);
+
 }

--- a/src/main/java/mealplanb/server/service/ChatService.java
+++ b/src/main/java/mealplanb/server/service/ChatService.java
@@ -85,6 +85,7 @@ public class ChatService {
      */
     public List<GetMealSuggestedFoodResponse> getMealSuggestedFood(Long memberId) {
         log.info("[ChatService.getMealSuggestedFood]");
+        memberService.checkMemberExist(memberId);
         return foodMealMappingTableService.getMealSuggestedFood(memberId);
     }
 }

--- a/src/main/java/mealplanb/server/service/ChatService.java
+++ b/src/main/java/mealplanb/server/service/ChatService.java
@@ -75,7 +75,7 @@ public class ChatService {
      * 채팅을 통한 끼니 등록
      */
     public void postMealSuggestedFood(Long memberId, FoodItem food) {
-        memberService.checkMemberExist(memberId);
+        log.info("[ChatService.postMealSuggestedFood]");
         mealService.postMealSuggestedFood(memberId, food);
     }
 }

--- a/src/main/java/mealplanb/server/service/ChatService.java
+++ b/src/main/java/mealplanb/server/service/ChatService.java
@@ -8,6 +8,7 @@ import mealplanb.server.dto.chat.GetAmountSuggestionResponse;
 import mealplanb.server.dto.chat.GetCheatDayFoodResponse;
 import mealplanb.server.dto.chat.GetCheatDayFoodResponse.cheatDayFoodInfo;
 import mealplanb.server.dto.chat.GetFavoriteFoodResponse;
+import mealplanb.server.dto.chat.GetMealSuggestedFoodResponse;
 import mealplanb.server.dto.meal.PostMealFoodRequest.FoodItem;
 import org.springframework.stereotype.Service;
 
@@ -77,5 +78,13 @@ public class ChatService {
     public void postMealSuggestedFood(Long memberId, FoodItem food) {
         log.info("[ChatService.postMealSuggestedFood]");
         mealService.postMealSuggestedFood(memberId, food);
+    }
+
+    /**
+     * 채팅을 통해 추천받은 끼니 조회 (등록식단 모아보기)
+     */
+    public List<GetMealSuggestedFoodResponse> getMealSuggestedFood(Long memberId) {
+        log.info("[ChatService.getMealSuggestedFood]");
+        return foodMealMappingTableService.getMealSuggestedFood(memberId);
     }
 }

--- a/src/main/java/mealplanb/server/service/FoodMealMappingTableService.java
+++ b/src/main/java/mealplanb/server/service/FoodMealMappingTableService.java
@@ -19,7 +19,6 @@ import mealplanb.server.dto.meal.MealTypeConverter;
 import mealplanb.server.repository.FoodMealMappingTableRepository;
 import mealplanb.server.repository.FoodRepository;
 import mealplanb.server.repository.MealRepository;
-import mealplanb.server.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
@@ -33,7 +32,6 @@ import static mealplanb.server.dto.meal.PostMealFoodRequest.*;
 @Service
 @RequiredArgsConstructor
 public class FoodMealMappingTableService {
-    private final MemberRepository memberRepository;
     private final FoodMealMappingTableRepository foodMealMappingTableRepository;
     private final FoodRepository foodRepository;
     private final MealRepository mealRepository;
@@ -147,8 +145,6 @@ public class FoodMealMappingTableService {
      */
     public List<GetMealSuggestedFoodResponse> getMealSuggestedFood(Long memberId) {
         log.info("[MealService.getMealSuggestedFood]");
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(()-> new MemberException(BaseExceptionResponseStatus.MEMBER_NOT_FOUND));
 
         List<FoodMealMappingTable> suggestedFoodList = foodMealMappingTableRepository.findAllMealSuggestedFood(memberId)
                 .orElse(Collections.emptyList());

--- a/src/main/java/mealplanb/server/service/MealService.java
+++ b/src/main/java/mealplanb/server/service/MealService.java
@@ -24,10 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 
 @Slf4j


### PR DESCRIPTION
## 개요
- 등록식단모아보기 api를 구현하였습니다.
- 채팅을 통해 등록한 식품을 모아볼 수 있는 api 입니다.
- [api 명세서](https://ultra-sound-723.notion.site/6178ea87585745b9b9b6cbb2ecae8209?v=3b6af13c3b7c4b82aa867aeeac174397&p=7cf35ba056c34c22b54d4f47ec84181c&pm=s)

## 작업사항
- postman 요청 결과
- ```localhost:9000/chat/meal ```
   <img width="626" alt="image" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/84059402/dae59a2b-f4a6-4d44-a673-7fe2ae5e9661">
<br/>

- 등록 식단이 없다면 다음과 같이 빈 리스트가 반환됩니다.
   <img width="625" alt="image" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/84059402/9ce607b5-e7be-4ba6-8463-70bb2f030907">

## 주의사항
- 
