### PR TITLE
Fix: Meal-49-BE-자동완성검색api 수정 => response에 유저등록여부 추가

### DIFF
--- a/src/main/java/mealplanb/server/controller/FoodController.java
+++ b/src/main/java/mealplanb/server/controller/FoodController.java
@@ -65,11 +65,12 @@ public class FoodController {
      * 자동완성 검색
      */
     @GetMapping("/auto-complete")
-    public BaseResponse<GetFoodAutoCompleteResponse> getAutoComplete(@RequestHeader(value = "Authorization", required = false) String authorization,
+    public BaseResponse<GetFoodAutoCompleteResponse> getAutoComplete(@RequestHeader(value = "Authorization") String authorization,
                                                               @RequestParam String query,
                                                               @RequestParam(defaultValue = "0") int page,
                                                               @RequestParam(defaultValue = "20") int size){
         log.info("[FoodController.getAutoComplete]");
-        return new BaseResponse<>(foodService.getAutoComplete(query, page, size));
+        Long memberId = jwtProvider.extractIdFromHeader(authorization);
+        return new BaseResponse<>(foodService.getAutoComplete(memberId, query, page, size));
     }
 }

--- a/src/main/java/mealplanb/server/dto/food/GetFavoriteFoodResponse.java
+++ b/src/main/java/mealplanb/server/dto/food/GetFavoriteFoodResponse.java
@@ -20,14 +20,6 @@ public class GetFavoriteFoodResponse {
         private Long foodId;
         private String foodName;
         private int kcal;
-        private boolean isMemberCreated;
-
-        public FoodItem(Food food) {
-            this.foodId = food.getFoodId();
-            this.foodName = food.getName();
-            this.kcal = (int) food.getKcal();
-            this.isMemberCreated = food.getCreateMemberId()==null?false:true;
-        }
     }
 
 }

--- a/src/main/java/mealplanb/server/dto/food/GetFavoriteFoodResponse.java
+++ b/src/main/java/mealplanb/server/dto/food/GetFavoriteFoodResponse.java
@@ -17,21 +17,18 @@ public class GetFavoriteFoodResponse {
 
     @Getter
     @Setter
+    @AllArgsConstructor
     public static class FoodItem {
         private Long foodId;
         private String foodName;
         private int kcal;
-
-        public FoodItem(Long foodId, String name, int kcal) {
-            this.foodId = foodId;
-            this.foodName = name;
-            this.kcal = kcal;
-        }
+        private boolean isMemberCreated;
 
         public FoodItem(Food food) {
             this.foodId = food.getFoodId();
             this.foodName = food.getName();
             this.kcal = (int) food.getKcal();
+            this.isMemberCreated = food.getCreateMemberId()==null?false:true;
         }
     }
 

--- a/src/main/java/mealplanb/server/dto/food/GetFoodAutoCompleteResponse.java
+++ b/src/main/java/mealplanb/server/dto/food/GetFoodAutoCompleteResponse.java
@@ -2,6 +2,8 @@ package mealplanb.server.dto.food;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
+import mealplanb.server.domain.Food.Food;
 
 import java.util.List;
 
@@ -13,5 +15,21 @@ public class GetFoodAutoCompleteResponse {
     /** 자동완성 검색 */
     private int currentPage;
     private int lastPage;
-    private List<FoodItem> foods;
+    private List<GetFoodAutoCompleteFoodItem> foods;
+
+    @Getter
+    @Setter
+    public static class GetFoodAutoCompleteFoodItem {
+        private Long foodId;
+        private String foodName;
+        private int kcal;
+        private boolean isMemberCreated;
+
+        public GetFoodAutoCompleteFoodItem(Food food) {
+            this.foodId = food.getFoodId();
+            this.foodName = food.getName();
+            this.kcal = (int) food.getKcal();
+            this.isMemberCreated = food.getCreateMemberId()==null?false:true;
+        }
+    }
 }

--- a/src/main/java/mealplanb/server/repository/FoodRepository.java
+++ b/src/main/java/mealplanb/server/repository/FoodRepository.java
@@ -14,6 +14,7 @@ public interface FoodRepository extends JpaRepository<Food, Long> {
     Optional<Food> findByFoodIdAndStatus(long foodId, BaseStatus a);
     @Query(value = "SELECT * " +
             "FROM food " +
-            "WHERE name LIKE %:query% AND status = 'A'" , nativeQuery = true)
-    Page<Food> getAutoComplete(@Param("query") String query, Pageable pageable);
+            "WHERE name LIKE %:query% AND status = 'A' " +
+            "AND (create_member_id = :memberId OR admin_approval = true)", nativeQuery = true)
+    Page<Food> getAutoComplete(@Param("memberId") Long memberId, @Param("query") String query, Pageable pageable);
 }

--- a/src/main/java/mealplanb/server/service/FavoriteFoodService.java
+++ b/src/main/java/mealplanb/server/service/FavoriteFoodService.java
@@ -87,7 +87,8 @@ public class FavoriteFoodService {
             GetFavoriteFoodResponse.FoodItem foodDto = new GetFavoriteFoodResponse.FoodItem(
                     favoriteFood.getFood().getFoodId(),
                     favoriteFood.getFood().getName(),
-                    (int)favoriteFood.getFood().getKcal()
+                    (int)favoriteFood.getFood().getKcal(),
+                    favoriteFood.getFood().getCreateMemberId()==null?false:true
             );
             return foodDto;
         }).collect(Collectors.toList());

--- a/src/main/java/mealplanb/server/service/FavoriteFoodService.java
+++ b/src/main/java/mealplanb/server/service/FavoriteFoodService.java
@@ -87,8 +87,7 @@ public class FavoriteFoodService {
             GetFavoriteFoodResponse.FoodItem foodDto = new GetFavoriteFoodResponse.FoodItem(
                     favoriteFood.getFood().getFoodId(),
                     favoriteFood.getFood().getName(),
-                    (int)favoriteFood.getFood().getKcal(),
-                    favoriteFood.getFood().getCreateMemberId()==null?false:true
+                    (int)favoriteFood.getFood().getKcal()
             );
             return foodDto;
         }).collect(Collectors.toList());

--- a/src/main/java/mealplanb/server/service/FoodService.java
+++ b/src/main/java/mealplanb/server/service/FoodService.java
@@ -14,6 +14,7 @@ import mealplanb.server.dto.chat.GetCheatDayFoodResponse.cheatDayFoodInfo;
 import mealplanb.server.dto.food.*;
 import mealplanb.server.dto.food.GetFavoriteFoodResponse.FoodItem;
 import mealplanb.server.domain.Member.Member;
+import mealplanb.server.dto.food.GetFoodAutoCompleteResponse.GetFoodAutoCompleteFoodItem;
 import mealplanb.server.dto.food.GetFoodResponse;
 import mealplanb.server.dto.food.PostNewFoodRequest;
 import mealplanb.server.dto.food.PostNewFoodResponse;
@@ -105,10 +106,10 @@ public class FoodService {
         log.info("[FoodService.GetFoodAutoCompleteResponse]");
         Pageable pageable = PageRequest.of(page, size);
         Page<Food> autoComplete = foodRepository.getAutoComplete(memberId, query.strip(), pageable);
-        List<FoodItem> foods = autoComplete.getContent().stream()
-                .map(FoodItem::new) // autoComplete.getContent()를 하면 List<Food>가 결과로 나오는데 각 요소인 Food를 FoodItem으로 변환
+        List<GetFoodAutoCompleteFoodItem> foods = autoComplete.getContent().stream()
+                .map(GetFoodAutoCompleteFoodItem::new) // autoComplete.getContent()를 하면 List<Food>가 결과로 나오는데 각 요소인 Food를 FoodItem으로 변환
                 .collect(Collectors.toList());
-        return new GetFoodAutoCompleteResponse(page, autoComplete.getTotalPages(), foods);
+        return new GetFoodAutoCompleteResponse(page, autoComplete.getTotalPages(),foods);
     }
 
     /**

--- a/src/main/java/mealplanb/server/service/FoodService.java
+++ b/src/main/java/mealplanb/server/service/FoodService.java
@@ -99,10 +99,10 @@ public class FoodService {
     /**
      * 자동완성 검색
      */
-    public GetFoodAutoCompleteResponse getAutoComplete(String query, int page, int size) {
+    public GetFoodAutoCompleteResponse getAutoComplete(Long memberId, String query, int page, int size) {
         log.info("[FoodService.GetFoodAutoCompleteResponse]");
         Pageable pageable = PageRequest.of(page, size);
-        Page<Food> autoComplete = foodRepository.getAutoComplete(query.strip(), pageable);
+        Page<Food> autoComplete = foodRepository.getAutoComplete(memberId, query.strip(), pageable);
         List<FoodItem> foods = autoComplete.getContent().stream()
                 .map(FoodItem::new) // autoComplete.getContent()를 하면 List<Food>가 결과로 나오는데 각 요소인 Food를 FoodItem으로 변환
                 .collect(Collectors.toList());


### PR DESCRIPTION
## 개요
- 자동완성검색api response에 유저등록여부 추가하였습니다.

## 작업사항
- 자신이 등록한 음식이나, 관리자가 승인한 음식만 검색될 수 있도록 하였습니다.
- response에 member_created를 추가하여, 사용자가 등록한 음식인지 여부를 파악할 수 있습니다.
- 즉, 검색결과에서 볼 수 있는 음식은 (자신이 등록한 음식, 관리자가 등록한 음식, 다른 사용자가 등록했지만 관리자가 승인한 음식) 입니다.

- postman 테스트 결과 
- `localhost:9000/food/auto-complete?query=치킨`
   <img width="626" alt="image" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/84059402/1f6070d0-7dbd-4ef8-9b0d-a99ed6a95560">


## 주의사항
