### PR TITLE
Fix: Meal-122-BE-나의식단api

### DIFF
--- a/src/main/java/mealplanb/server/controller/FavoriteMealController.java
+++ b/src/main/java/mealplanb/server/controller/FavoriteMealController.java
@@ -11,6 +11,8 @@ import mealplanb.server.service.FavoriteMealService;
 import mealplanb.server.util.jwt.JwtProvider;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -59,8 +61,8 @@ public class FavoriteMealController {
      * 나의 식단 선택해서 식사 리스트 조회하기
      */
     @GetMapping("/{favoriteMealId}")
-    public BaseResponse<GetMyMealListResponse> getMyMealList(@RequestHeader("Authorization") String authorization,
-                                                             @PathVariable Long favoriteMealId){
+    public BaseResponse<List<GetMyMealListResponse>> getMyMealList(@RequestHeader("Authorization") String authorization,
+                                                                   @PathVariable Long favoriteMealId){
         log.info("[FavoriteMealController.getMyMealList]");
         Long memberId = jwtProvider.extractIdFromHeader(authorization);
         return new BaseResponse<>(favoriteMealService.getMyMealList(memberId, favoriteMealId));

--- a/src/main/java/mealplanb/server/controller/FavoriteMealController.java
+++ b/src/main/java/mealplanb/server/controller/FavoriteMealController.java
@@ -38,7 +38,7 @@ public class FavoriteMealController {
      * 나의 식단 조회
      */
     @GetMapping("")
-    public BaseResponse<GetMyMealResponse> getMyMeal(@RequestHeader ("Authorization") String authorization){
+    public BaseResponse<List<GetMyMealResponse>> getMyMeal(@RequestHeader ("Authorization") String authorization){
         log.info("[FavoriteMealController.getMyMeal]");
         Long memberId = jwtProvider.extractIdFromHeader(authorization);
         return new BaseResponse<>(favoriteMealService.getMyMeal(memberId));

--- a/src/main/java/mealplanb/server/dto/meal/GetMyMealListResponse.java
+++ b/src/main/java/mealplanb/server/dto/meal/GetMyMealListResponse.java
@@ -12,23 +12,9 @@ public class GetMyMealListResponse {
     /**
      * 나의 식단 선택해서 식사 리스트 조회하기
      */
-    private List<GetMyMealItem> myMealItemList;
-
-    @Getter
-    @NoArgsConstructor
-    public static class GetMyMealItem{
-        private long foodId;
-        private String foodName;
-        private int quantity;
-        private int kcal;
-
-        public GetMyMealItem(long foodId, String foodName, int quantity, int kcal){
-            this.foodId = foodId;
-            this.foodName = foodName;
-            this.quantity = quantity;
-            this.kcal = kcal;
-        }
-    }
-
+    private long foodId;
+    private String foodName;
+    private int quantity;
+    private int kcal;
 
 }

--- a/src/main/java/mealplanb/server/dto/meal/GetMyMealResponse.java
+++ b/src/main/java/mealplanb/server/dto/meal/GetMyMealResponse.java
@@ -2,10 +2,6 @@ package mealplanb.server.dto.meal;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
-import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -13,22 +9,8 @@ public class GetMyMealResponse {
     /**
      * 나의 식단 조회
      */
-    private List<FavoriteMealItem> mealItemList;
-
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    public static class FavoriteMealItem{
-        private long favoriteMealId;
-        private String favoriteMealName;
-        private int mealKcal;
-        private int foodCount; // 내용물 개수
-
-        public FavoriteMealItem(Long favoriteMealId, String favoriteMealName, int totalKcal, int foodCount) {
-            this.favoriteMealId = favoriteMealId;
-            this.favoriteMealName = favoriteMealName;
-            this.mealKcal = totalKcal;
-            this.foodCount = foodCount;
-        }
-    }
+    private long favoriteMealId;
+    private String favoriteMealName;
+    private int mealKcal;
+    private int foodCount; // 내용물 개수
 }

--- a/src/main/java/mealplanb/server/service/FavoriteMealComponentService.java
+++ b/src/main/java/mealplanb/server/service/FavoriteMealComponentService.java
@@ -9,7 +9,7 @@ import mealplanb.server.domain.FavoriteMeal;
 import mealplanb.server.domain.FavoriteMealComponent;
 import mealplanb.server.domain.Food.Food;
 import mealplanb.server.dto.meal.GetMyMealListResponse;
-import mealplanb.server.dto.meal.GetMyMealResponse.FavoriteMealItem;
+import mealplanb.server.dto.meal.GetMyMealResponse;
 import mealplanb.server.dto.meal.PostMyMealRequest;
 import mealplanb.server.repository.FavoriteMealComponentRepository;
 import mealplanb.server.repository.FoodRepository;
@@ -57,9 +57,9 @@ public class FavoriteMealComponentService {
     /**
      * 나의 식단 조회
      */
-    public List<FavoriteMealItem> getFavoriteMealComponentList(List<FavoriteMeal> favoriteMeal){
+    public List<GetMyMealResponse> getFavoriteMealComponentList(List<FavoriteMeal> favoriteMeal){
         log.info("[FavoriteMealComponentService.getFavoriteMealComponentList]");
-        List<FavoriteMealItem> mealItemList = new ArrayList<>();
+        List<GetMyMealResponse> mealItemList = new ArrayList<>();
 
         int totalKcal = 0;
         for(FavoriteMeal meal : favoriteMeal){
@@ -74,7 +74,7 @@ public class FavoriteMealComponentService {
                 // 식재료 량에 따라 칼로리 계산
                 totalKcal += (int)(food.getKcal() * component.getQuantity() / 100);
             }
-            FavoriteMealItem mealItem = new FavoriteMealItem(
+            GetMyMealResponse mealItem = new GetMyMealResponse(
                     favoriteMealId,
                     meal.getFavoriteMealName(),
                     totalKcal,

--- a/src/main/java/mealplanb/server/service/FavoriteMealComponentService.java
+++ b/src/main/java/mealplanb/server/service/FavoriteMealComponentService.java
@@ -103,9 +103,9 @@ public class FavoriteMealComponentService {
     /**
      * 나의 식단 선택해서 식사 리스트 조회하기
      */
-    public List<GetMyMealListResponse.GetMyMealItem> getMyMealList(Long favoriteMealId){
+    public List<GetMyMealListResponse> getMyMealList(Long favoriteMealId){
         log.info("[FavoriteMealComponentService.getMyMealList]");
-        List<GetMyMealListResponse.GetMyMealItem> myMealItemList = new ArrayList<>();
+        List<GetMyMealListResponse> myMealItemList = new ArrayList<>();
 
         List<FavoriteMealComponent> favoriteMealComponentList = favoriteMealComponentRepository.findByFavoriteMeal_FavoriteMealIdAndStatus(favoriteMealId,BaseStatus.A)
                 .orElseThrow(()->new MealException(FAVORITE_MEAL_COMPONENT_NOT_EXIST));
@@ -119,7 +119,7 @@ public class FavoriteMealComponentService {
             // 식재료 량에 따라 칼로리 계산
             kcal = (int)(food.getKcal() * component.getQuantity() / 100);
 
-            GetMyMealListResponse.GetMyMealItem getMyMealItem= new GetMyMealListResponse.GetMyMealItem(
+            GetMyMealListResponse getMyMealItem= new GetMyMealListResponse(
                     foodId,
                     food.getName(),
                     component.getQuantity(),

--- a/src/main/java/mealplanb/server/service/FavoriteMealService.java
+++ b/src/main/java/mealplanb/server/service/FavoriteMealService.java
@@ -96,7 +96,7 @@ public class FavoriteMealService {
     /**
      * 나의 식단 선택해서 식사 리스트 조회하기
      */
-    public GetMyMealListResponse getMyMealList(Long memberId, Long favoriteMealId){
+    public List<GetMyMealListResponse> getMyMealList(Long memberId, Long favoriteMealId){
         log.info("[FavoriteMealService.getMyMealList]");
 
         if(memberRepository.findById(memberId).isEmpty()){
@@ -106,6 +106,6 @@ public class FavoriteMealService {
         if(!favoriteMealRepository.existsByFavoriteMealIdAndStatus(favoriteMealId, BaseStatus.A)){
             throw new MealException(MEAL_NOT_FOUND); // 식단을 찾을 수 없습니다.
         }
-        return new GetMyMealListResponse(favoriteMealComponentService.getMyMealList(favoriteMealId));
+        return favoriteMealComponentService.getMyMealList(favoriteMealId);
     }
 }

--- a/src/main/java/mealplanb/server/service/FavoriteMealService.java
+++ b/src/main/java/mealplanb/server/service/FavoriteMealService.java
@@ -27,6 +27,7 @@ import static mealplanb.server.common.response.status.BaseExceptionResponseStatu
 @Transactional(readOnly = true)
 public class FavoriteMealService {
 
+    private final MemberService memberService;
     private final MemberRepository memberRepository;
     private final FavoriteMealRepository favoriteMealRepository;
     private final FavoriteMealComponentService favoriteMealComponentService;
@@ -99,9 +100,7 @@ public class FavoriteMealService {
     public List<GetMyMealListResponse> getMyMealList(Long memberId, Long favoriteMealId){
         log.info("[FavoriteMealService.getMyMealList]");
 
-        if(memberRepository.findById(memberId).isEmpty()){
-            throw new MemberException(MEMBER_NOT_FOUND);
-        }
+        memberService.checkMemberExist(memberId);
 
         if(!favoriteMealRepository.existsByFavoriteMealIdAndStatus(favoriteMealId, BaseStatus.A)){
             throw new MealException(MEAL_NOT_FOUND); // 식단을 찾을 수 없습니다.

--- a/src/main/java/mealplanb/server/service/FavoriteMealService.java
+++ b/src/main/java/mealplanb/server/service/FavoriteMealService.java
@@ -10,7 +10,6 @@ import mealplanb.server.domain.FavoriteMeal;
 import mealplanb.server.domain.Member.Member;
 import mealplanb.server.dto.meal.GetMyMealListResponse;
 import mealplanb.server.dto.meal.GetMyMealResponse;
-import mealplanb.server.dto.meal.GetMyMealResponse.FavoriteMealItem;
 import mealplanb.server.dto.meal.PostMyMealRequest;
 import mealplanb.server.repository.FavoriteMealRepository;
 import mealplanb.server.repository.MemberRepository;
@@ -65,7 +64,7 @@ public class FavoriteMealService {
     /**
      * 나의 식단 조회
      */
-    public GetMyMealResponse getMyMeal(Long memberId){
+    public List<GetMyMealResponse> getMyMeal(Long memberId){
         log.info("[FavoriteMealService.getMyMeal]");
 
         memberService.checkMemberExist(memberId);
@@ -73,8 +72,7 @@ public class FavoriteMealService {
         List<FavoriteMeal> favoriteMeal = favoriteMealRepository.findByMember_MemberIdAndStatus(memberId,BaseStatus.A)
                 .orElseThrow(()-> new MealException(FAVORITE_MEAL_NOT_EXIST));
 
-        List<FavoriteMealItem> favoriteMealComponentList = favoriteMealComponentService.getFavoriteMealComponentList(favoriteMeal);
-        return new GetMyMealResponse(favoriteMealComponentList);
+        return favoriteMealComponentService.getFavoriteMealComponentList(favoriteMeal);
     }
 
     /**

--- a/src/main/java/mealplanb/server/service/FavoriteMealService.java
+++ b/src/main/java/mealplanb/server/service/FavoriteMealService.java
@@ -68,9 +68,7 @@ public class FavoriteMealService {
     public GetMyMealResponse getMyMeal(Long memberId){
         log.info("[FavoriteMealService.getMyMeal]");
 
-        if(memberRepository.findById(memberId).isEmpty()){
-            throw new MemberException(MEMBER_NOT_FOUND);
-        }
+        memberService.checkMemberExist(memberId);
 
         List<FavoriteMeal> favoriteMeal = favoriteMealRepository.findByMember_MemberIdAndStatus(memberId,BaseStatus.A)
                 .orElseThrow(()-> new MealException(FAVORITE_MEAL_NOT_EXIST));


### PR DESCRIPTION
## 개요
- 기존 나의 식단 조회가 이런식으로 한번더 list 로 감싸져서 반환되었는데 불필요하게 감싸는 것 같아서 수정하는 작업 진행하였습니다.
<img width="460" alt="스크린샷 2024-02-17 오후 10 43 12" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/122519994/bf330c11-5d4d-462b-afaf-c093b19eadad">

## 작업사항
- GetMyMealResponse 와 GetMyMealListResponse 수정하였습니다. 수정된 api 명세서입니다. 
- [나의 식단 선택해서 식사 리스트 조회하기](https://ultra-sound-723.notion.site/my-meal-favorite_meal_id-c923b54bd1024cc6ac378c4ecc44770e?pvs=4) 
- [“나의식단”을 누르면 내가 만든 식단 조회](https://ultra-sound-723.notion.site/my-meal-5e4215b2020044ffad5102685f7a44ec?pvs=4)

## 주의사항
