### PR TITLE
Feat: Meal-120-BE-최근추천api

### DIFF
--- a/src/main/java/mealplanb/server/controller/ChatController.java
+++ b/src/main/java/mealplanb/server/controller/ChatController.java
@@ -6,9 +6,10 @@ import mealplanb.server.common.response.BaseResponse;
 import mealplanb.server.dto.chat.GetAmountSuggestionResponse;
 import mealplanb.server.dto.chat.GetCheatDayFoodResponse;
 import mealplanb.server.dto.chat.GetMealSuggestedFoodResponse;
-import mealplanb.server.dto.meal.PostMealFoodRequest;
+import mealplanb.server.dto.food.GetFavoriteFoodResponse;
 import mealplanb.server.dto.chat.GetMostEatenFoodResponse;
 import mealplanb.server.service.ChatService;
+import mealplanb.server.service.FoodMealMappingTableService;
 import mealplanb.server.util.jwt.JwtProvider;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,6 +24,7 @@ import static mealplanb.server.dto.meal.PostMealFoodRequest.*;
 public class ChatController {
     private final JwtProvider jwtProvider;
     private final ChatService chatService;
+    private final FoodMealMappingTableService foodMealMappingTableService;
 
     /**
      * 채팅(치팅데이)
@@ -86,6 +88,16 @@ public class ChatController {
         log.info("[ChatController.getMealSuggestedFood]");
         Long memberId = jwtProvider.extractIdFromHeader(authorization);
         return new BaseResponse<>(chatService.getMealSuggestedFood(memberId));
+    }
+
+    /**
+     * “최근추천”을 누르면 추천받은 식사 조회
+     */
+    @GetMapping("/recommended-meal")
+    public BaseResponse<List<GetFavoriteFoodResponse>> getRecommendedFoodList(@RequestHeader("Authorization") String authorization){
+        log.info("[ChatController.getRecommendedFoodList]");
+        Long memberId = jwtProvider.extractIdFromHeader(authorization);
+        return new BaseResponse<>(foodMealMappingTableService.getRecommendedFoodList(memberId));
     }
 
 }

--- a/src/main/java/mealplanb/server/controller/FavoriteFoodController.java
+++ b/src/main/java/mealplanb/server/controller/FavoriteFoodController.java
@@ -6,9 +6,10 @@ import mealplanb.server.common.response.BaseResponse;
 import mealplanb.server.dto.food.GetFavoriteFoodResponse;
 import mealplanb.server.dto.food.PostFavoriteFoodRequest;
 import mealplanb.server.service.FavoriteFoodService;
-import mealplanb.server.service.MemberService;
 import mealplanb.server.util.jwt.JwtProvider;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -35,7 +36,7 @@ public class FavoriteFoodController {
      * 즐겨찾기 식사 조회
      */
     @GetMapping("")
-    public BaseResponse<GetFavoriteFoodResponse> getFavoriteFoodList(@RequestHeader("Authorization") String authorization){
+    public BaseResponse<List<GetFavoriteFoodResponse>> getFavoriteFoodList(@RequestHeader("Authorization") String authorization){
         log.info("[MemberController.getFavoriteFoodList]");
         Long memberId = jwtProvider.extractIdFromHeader(authorization);
         return new BaseResponse<>(favoriteFoodService.getFavoriteFoodList(memberId));

--- a/src/main/java/mealplanb/server/dto/food/GetFavoriteFoodResponse.java
+++ b/src/main/java/mealplanb/server/dto/food/GetFavoriteFoodResponse.java
@@ -2,24 +2,15 @@ package mealplanb.server.dto.food;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
-import mealplanb.server.domain.Food.Food;
-
-import java.util.List;
 
 @Getter
 @AllArgsConstructor
 public class GetFavoriteFoodResponse {
-    /** 즐겨찾기한 식품 조회 */
-    private List<FoodItem> foods;
 
-    @Getter
-    @Setter
-    @AllArgsConstructor
-    public static class FoodItem {
-        private Long foodId;
-        private String foodName;
-        private int kcal;
-    }
-
+    /**
+     * 즐겨찾기한 식품 조회 & “최근추천”을 누르면 추천받은 식사 조회
+     */
+    private Long foodId;
+    private String foodName;
+    private int kcal;
 }

--- a/src/main/java/mealplanb/server/repository/FoodMealMappingTableRepository.java
+++ b/src/main/java/mealplanb/server/repository/FoodMealMappingTableRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 public interface FoodMealMappingTableRepository extends JpaRepository<FoodMealMappingTable, Long> {
     Optional<List<FoodMealMappingTable>> findAllByMeal_MealIdAndStatus(long mealId, BaseStatus a);
-    Optional<List<FoodMealMappingTable>> findByMember_MemberIdAndIsRecommendedAndStatus(Long memberId, int isRecommended, BaseStatus A);
+    Optional<List<FoodMealMappingTable>> findByMember_MemberIdAndIsRecommendedAndStatus(Long memberId, boolean isRecommended, BaseStatus A);
 
     @Query(value = "SELECT fm.food_id " +
             "FROM food_meal_mapping_table fm " +

--- a/src/main/java/mealplanb/server/repository/FoodMealMappingTableRepository.java
+++ b/src/main/java/mealplanb/server/repository/FoodMealMappingTableRepository.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 public interface FoodMealMappingTableRepository extends JpaRepository<FoodMealMappingTable, Long> {
     Optional<List<FoodMealMappingTable>> findAllByMeal_MealIdAndStatus(long mealId, BaseStatus a);
+    Optional<List<FoodMealMappingTable>> findByMember_MemberIdAndIsRecommendedAndStatus(Long memberId, int isRecommended, BaseStatus A);
 
     @Query(value = "SELECT fm.food_id " +
             "FROM food_meal_mapping_table fm " +

--- a/src/main/java/mealplanb/server/repository/FoodMealMappingTableRepository.java
+++ b/src/main/java/mealplanb/server/repository/FoodMealMappingTableRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 public interface FoodMealMappingTableRepository extends JpaRepository<FoodMealMappingTable, Long> {
     Optional<List<FoodMealMappingTable>> findAllByMeal_MealIdAndStatus(long mealId, BaseStatus a);
-    Optional<List<FoodMealMappingTable>> findByMember_MemberIdAndIsRecommendedAndStatus(Long memberId, boolean isRecommended, BaseStatus A);
+    Optional<List<FoodMealMappingTable>> findByMember_MemberIdAndIsRecommendedAndStatusOrderByCreatedAtDesc(Long memberId, boolean isRecommended, BaseStatus A);
 
     @Query(value = "SELECT fm.food_id " +
             "FROM food_meal_mapping_table fm " +

--- a/src/main/java/mealplanb/server/repository/FoodMealMappingTableRepository.java
+++ b/src/main/java/mealplanb/server/repository/FoodMealMappingTableRepository.java
@@ -3,6 +3,7 @@ package mealplanb.server.repository;
 import mealplanb.server.domain.Base.BaseStatus;
 import mealplanb.server.domain.FoodMealMappingTable;
 import mealplanb.server.domain.Meal.Meal;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,7 +13,7 @@ import java.util.Optional;
 
 public interface FoodMealMappingTableRepository extends JpaRepository<FoodMealMappingTable, Long> {
     Optional<List<FoodMealMappingTable>> findAllByMeal_MealIdAndStatus(long mealId, BaseStatus a);
-    Optional<List<FoodMealMappingTable>> findByMember_MemberIdAndIsRecommendedAndStatusOrderByCreatedAtDesc(Long memberId, boolean isRecommended, BaseStatus A);
+    Optional<List<FoodMealMappingTable>> findByMember_MemberIdAndIsRecommendedAndStatusOrderByCreatedAtDesc(Long memberId, boolean isRecommended, Pageable pageable,BaseStatus A);
 
     @Query(value = "SELECT fm.food_id " +
             "FROM food_meal_mapping_table fm " +

--- a/src/main/java/mealplanb/server/service/FavoriteFoodService.java
+++ b/src/main/java/mealplanb/server/service/FavoriteFoodService.java
@@ -78,27 +78,26 @@ public class FavoriteFoodService {
         log.info("[FavoriteFoodService.getFavoriteFoodList]");
         memberService.checkMemberExist(memberId);
 
-        List<GetFavoriteFoodResponse> favoriteFoodList = new ArrayList<>();
-        List<FavoriteFood> favoriteFoodListOptional = favoriteFoodRepository.findByMember_MemberIdAndStatus(memberId,BaseStatus.A).get();
+        List<GetFavoriteFoodResponse> favoriteFoods = new ArrayList<>();
+        Optional<List<FavoriteFood>>favoriteFoodListOptional = favoriteFoodRepository.findByMember_MemberIdAndStatus(memberId,BaseStatus.A);
 
-        if(favoriteFoodListOptional.isEmpty()){
-            return favoriteFoodList;
-        }
+        favoriteFoodListOptional.ifPresent(favoriteFoodList->{
+                for(FavoriteFood food : favoriteFoodList) {
+                    Long foodId = food.getFood().getFoodId();
+                    String foodName = food.getFood().getName();
+                    int kcal = (int) food.getFood().getKcal();
 
-        for(FavoriteFood food : favoriteFoodListOptional){
-            Long foodId = food.getFood().getFoodId();
-            String foodName = food.getFood().getName();
-            int kcal = (int) food.getFood().getKcal();
+                    GetFavoriteFoodResponse foodItem = new GetFavoriteFoodResponse(
+                            foodId,
+                            foodName,
+                            kcal
+                    );
 
-            GetFavoriteFoodResponse foodItem = new GetFavoriteFoodResponse(
-                    foodId,
-                    foodName,
-                    kcal
-            );
-
-            favoriteFoodList.add(foodItem);
-        }
-        return favoriteFoodList;
+                    favoriteFoods.add(foodItem);
+                }
+            }
+        );
+        return favoriteFoods;
     }
 
     /**

--- a/src/main/java/mealplanb/server/service/FoodMealMappingTableService.java
+++ b/src/main/java/mealplanb/server/service/FoodMealMappingTableService.java
@@ -10,6 +10,7 @@ import mealplanb.server.common.exception.FoodException;
 import mealplanb.server.common.response.status.BaseExceptionResponseStatus;
 import mealplanb.server.domain.FoodMealMappingTable;
 import mealplanb.server.dto.chat.GetMealSuggestedFoodResponse;
+import mealplanb.server.dto.food.GetFavoriteFoodResponse;
 import mealplanb.server.dto.meal.GetMealFoodResponse.FoodInfo;
 import mealplanb.server.domain.Meal.Meal;
 import mealplanb.server.domain.Member.Member;
@@ -170,5 +171,26 @@ public class FoodMealMappingTableService {
     public static String convertMealDateLabel(DayOfWeek dayOfWeek) {
         // 요일에 따라 한글 요일을 반환
         return dayOfWeek.getDisplayName(TextStyle.FULL, Locale.KOREAN);
+    }
+
+    public List<GetFavoriteFoodResponse> getRecommendedFoodList(Long memberId){
+        log.info("[FoodMealMappingTableService.getRecommendedFoodList]");
+        List<GetFavoriteFoodResponse> recommendedFoodList = new ArrayList<>();
+
+        List<FoodMealMappingTable> FoodList = foodMealMappingTableRepository.findByMember_MemberIdAndIsRecommendedAndStatus(memberId,1,BaseStatus.A).get();
+
+        for(FoodMealMappingTable component : FoodList){
+            Long foodId = component.getFood().getFoodId();
+            String foodName = component.getFood().getName();
+            int kcal = (int) component.getFood().getKcal();
+
+            GetFavoriteFoodResponse foodItem = new GetFavoriteFoodResponse(
+                    foodId,
+                    foodName,
+                    kcal
+            );
+            recommendedFoodList.add(foodItem);
+        }
+        return recommendedFoodList;
     }
 }

--- a/src/main/java/mealplanb/server/service/FoodMealMappingTableService.java
+++ b/src/main/java/mealplanb/server/service/FoodMealMappingTableService.java
@@ -177,7 +177,7 @@ public class FoodMealMappingTableService {
         log.info("[FoodMealMappingTableService.getRecommendedFoodList]");
         List<GetFavoriteFoodResponse> recommendedFoodList = new ArrayList<>();
 
-        List<FoodMealMappingTable> FoodList = foodMealMappingTableRepository.findByMember_MemberIdAndIsRecommendedAndStatus(memberId,true,BaseStatus.A).get();
+        List<FoodMealMappingTable> FoodList = foodMealMappingTableRepository.findByMember_MemberIdAndIsRecommendedAndStatusOrderByCreatedAtDesc(memberId,true,BaseStatus.A).get();
 
         if(FoodList.isEmpty()){
             return recommendedFoodList;

--- a/src/main/java/mealplanb/server/service/FoodMealMappingTableService.java
+++ b/src/main/java/mealplanb/server/service/FoodMealMappingTableService.java
@@ -18,6 +18,8 @@ import mealplanb.server.dto.meal.MealTypeConverter;
 import mealplanb.server.repository.FoodMealMappingTableRepository;
 import mealplanb.server.repository.FoodRepository;
 import mealplanb.server.repository.MealRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
@@ -176,8 +178,8 @@ public class FoodMealMappingTableService {
     public List<GetFavoriteFoodResponse> getRecommendedFoodList(Long memberId){
         log.info("[FoodMealMappingTableService.getRecommendedFoodList]");
         List<GetFavoriteFoodResponse> recommendedFoodList = new ArrayList<>();
-
-        List<FoodMealMappingTable> FoodList = foodMealMappingTableRepository.findByMember_MemberIdAndIsRecommendedAndStatusOrderByCreatedAtDesc(memberId,true,BaseStatus.A).get();
+        Pageable pageable = PageRequest.of(0, 20);
+        List<FoodMealMappingTable> FoodList = foodMealMappingTableRepository.findByMember_MemberIdAndIsRecommendedAndStatusOrderByCreatedAtDesc(memberId,true, pageable, BaseStatus.A).get();
 
         if(FoodList.isEmpty()){
             return recommendedFoodList;

--- a/src/main/java/mealplanb/server/service/FoodMealMappingTableService.java
+++ b/src/main/java/mealplanb/server/service/FoodMealMappingTableService.java
@@ -177,7 +177,11 @@ public class FoodMealMappingTableService {
         log.info("[FoodMealMappingTableService.getRecommendedFoodList]");
         List<GetFavoriteFoodResponse> recommendedFoodList = new ArrayList<>();
 
-        List<FoodMealMappingTable> FoodList = foodMealMappingTableRepository.findByMember_MemberIdAndIsRecommendedAndStatus(memberId,1,BaseStatus.A).get();
+        List<FoodMealMappingTable> FoodList = foodMealMappingTableRepository.findByMember_MemberIdAndIsRecommendedAndStatus(memberId,true,BaseStatus.A).get();
+
+        if(FoodList.isEmpty()){
+            return recommendedFoodList;
+        }
 
         for(FoodMealMappingTable component : FoodList){
             Long foodId = component.getFood().getFoodId();

--- a/src/main/java/mealplanb/server/service/FoodService.java
+++ b/src/main/java/mealplanb/server/service/FoodService.java
@@ -12,7 +12,6 @@ import mealplanb.server.domain.Food.FoodUnit;
 import mealplanb.server.dto.chat.GetAmountSuggestionResponse;
 import mealplanb.server.dto.chat.GetCheatDayFoodResponse.cheatDayFoodInfo;
 import mealplanb.server.dto.food.*;
-import mealplanb.server.dto.food.GetFavoriteFoodResponse.FoodItem;
 import mealplanb.server.domain.Member.Member;
 import mealplanb.server.dto.food.GetFoodAutoCompleteResponse.GetFoodAutoCompleteFoodItem;
 import mealplanb.server.dto.food.GetFoodResponse;


### PR DESCRIPTION
## 개요
- 채팅으로 최근 추천받은 음식 최대 20개까지 음식만 보여주는 api 구현하였습니다.

## 작업사항
- response 를 살펴보다보니까 GetFavoriteFoodResponse 랑 동일한 형식으로 반환하는 것 같아서 GetFavoriteFoodResponse 를 사용하였습니다. 그 과정에서 즐겨찾기한 식사 조회 api response 가 조금 달라지게 되었습니다. [즐겨찾기한 식사 조회](https://ultra-sound-723.notion.site/favorite-food-1b009c2ff9b445429e16ddbe1498fb80?pvs=4) (즐겨찾기한 식사 조회 와 최근 추천api 두개에 모두 적절한 dto 이름이 잘 떠오르지 않아서 그냥 GetFavoriteFoodResponse 로 두고 사용하였습니다.. 좋은 아이디어 있으시면 알려주시면 좋겠습니다!)
- https://www.notion.so/0209-c1b64544e0624bb28fc6ccb67d6c74ea?pvs=4#117786edc49540fc8ee80de87279f31c 음식양은 제외하고 음식만 추천해주신다고 하셔서 id, 이름, 100 그램당 칼로리 반환하도록 구현하였습니다.
- 최근 추천받은 음식이 먼저 뜨도록 정렬해서 반환하였습니다.

## 주의사항
```
http://localhost:9000/chat/recommended-meal
```
<img width="562" alt="스크린샷 2024-02-18 오후 9 11 28" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/122519994/b72b7ef0-ef90-40ba-8c63-f3a5d09fec67">

- 최근 추천에 대한 postman 테스트 결과입니다.
<br>
<br>
<br>

```
http://localhost:9000/favorite-food
```
<img width="562" alt="스크린샷 2024-02-18 오후 9 12 09" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/122519994/d265105e-4db9-4e6d-bcea-7aafcd96bfc1">

- response 모습이 달라진 즐겨찾기한 식사 리스트 조회 api 입니다. 기존에는 foods 라는 리스트로 한번 더 묶여있었는데 불필요한 것 같아서 현재 response 대로 반환하게되었습니다.