### PR TITLE
Feat: MEAL-34-BE-로그아웃api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     // Json을 결과로 매핑하기 위한 의존성 추가
     implementation 'com.google.code.gson:gson:2.8.6'
 
+    // Spring Boot Redis Starter
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/mealplanb/server/common/interceptor/.gitkeep
+++ b/src/main/java/mealplanb/server/common/interceptor/.gitkeep
@@ -1,5 +1,0 @@
-mkdir interceptor
-touch interceptor/.gitkeep
-git add interceptor/.gitkeep
-git commit -m "Add empty interceptor directory"
-git push origin main

--- a/src/main/java/mealplanb/server/common/interceptor/TokenInterceptor.java
+++ b/src/main/java/mealplanb/server/common/interceptor/TokenInterceptor.java
@@ -1,0 +1,33 @@
+package mealplanb.server.common.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import mealplanb.server.common.exception.MemberException;
+import mealplanb.server.service.TokenService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import static mealplanb.server.common.response.status.BaseExceptionResponseStatus.INVALID_TOKEN;
+
+@Component
+@RequiredArgsConstructor
+public class TokenInterceptor implements HandlerInterceptor {
+
+    private final TokenService tokenService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String token = request.getHeader("Authorization");
+        if (token != null && !token.isEmpty()) {
+            // "Bearer " 접두사 제거
+            token = token.replace("Bearer ", "");
+            // 토큰 존재 여부 확인
+            if (!tokenService.checkTokenExists(token)) {
+                throw new MemberException(INVALID_TOKEN);
+            }
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/mealplanb/server/config/RedisConfig.java
+++ b/src/main/java/mealplanb/server/config/RedisConfig.java
@@ -1,0 +1,16 @@
+package mealplanb.server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        return template;
+    }
+}

--- a/src/main/java/mealplanb/server/config/WebMvcConfig.java
+++ b/src/main/java/mealplanb/server/config/WebMvcConfig.java
@@ -1,0 +1,24 @@
+package mealplanb.server.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import mealplanb.server.common.interceptor.TokenInterceptor;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final TokenInterceptor tokenInterceptor;
+
+    @Autowired
+    public WebMvcConfig(TokenInterceptor tokenInterceptor) {
+        this.tokenInterceptor = tokenInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(tokenInterceptor).addPathPatterns("/**");
+        // 모든 경로("/**")에 대해 TokenInterceptor를 적용
+    }
+}

--- a/src/main/java/mealplanb/server/controller/MemberController.java
+++ b/src/main/java/mealplanb/server/controller/MemberController.java
@@ -52,9 +52,10 @@ public class MemberController {
      * 로그아웃
      */
     @PostMapping("/logout")
-    public BaseResponse<Void> logout(@RequestHeader("Authorization") String authorizationHeader){
+    public BaseResponse<Void> logout(@RequestHeader("Authorization") String authorization){
         log.info("[MemberController.logout]");
-        memberService.logout(authorizationHeader);
+        String jwtToken = jwtProvider.extractJwtToken(authorization);
+        memberService.logout(jwtToken);
         return new BaseResponse<>(null);
     }
 

--- a/src/main/java/mealplanb/server/controller/MemberController.java
+++ b/src/main/java/mealplanb/server/controller/MemberController.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mealplanb.server.common.exception.MemberException;
 import mealplanb.server.common.response.BaseResponse;
-import mealplanb.server.dto.food.GetFavoriteFoodResponse;
-import mealplanb.server.dto.food.PostFavoriteFoodRequest;
 import mealplanb.server.dto.member.*;
-import mealplanb.server.service.FavoriteFoodService;
 import mealplanb.server.service.MemberService;
 import mealplanb.server.util.jwt.JwtProvider;
 import org.springframework.validation.BindingResult;
@@ -49,6 +46,16 @@ public class MemberController {
             throw new MemberException(MEMBER_NOT_FOUND, getErrorMessages(bindingResult));
         }
         return new BaseResponse<>(memberService.login(postLoginRequest));
+    }
+
+    /**
+     * 로그아웃
+     */
+    @PostMapping("/logout")
+    public BaseResponse<Void> logout(@RequestHeader("Authorization") String authorizationHeader){
+        log.info("[MemberController.logout]");
+        memberService.logout(authorizationHeader);
+        return new BaseResponse<>(null);
     }
 
     /**

--- a/src/main/java/mealplanb/server/service/MemberService.java
+++ b/src/main/java/mealplanb/server/service/MemberService.java
@@ -218,10 +218,8 @@ public class MemberService {
     /**
      * 로그아웃
      */
-    public void logout(String authorizationHeader){
+    public void logout(String jwtToken){
         log.info("[MemberService.logout]");
-        String jwtToken = authorizationHeader.substring(7); // "Bearer " 부분을 제외하고 토큰 추출
-
         if(jwtProvider.isExpiredToken(jwtToken)){
             throw new MemberException(EXPIRED_TOKEN);
         }

--- a/src/main/java/mealplanb/server/service/TokenService.java
+++ b/src/main/java/mealplanb/server/service/TokenService.java
@@ -1,0 +1,37 @@
+package mealplanb.server.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    @Value("${secret.jwt-expired-in}")
+    private long JWT_EXPIRED_IN;
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void storeToken(String token, long memberId) {
+        // redis 에 토큰 저장
+        redisTemplate.opsForValue().set(token, memberId, JWT_EXPIRED_IN, TimeUnit.MILLISECONDS);
+    }
+
+    public boolean checkTokenExists(String token) {
+        // 들어온 토큰이 redis 에 있는지 확인
+        Boolean result = redisTemplate.hasKey(token);
+        return result != null && result;
+    }
+
+    public void invalidateToken(String token) {
+        // redis 에서 토큰 삭제
+        redisTemplate.delete(token);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -147,3 +147,8 @@ spring:
             client-name: kakao
             scope:
               - profile_nickname
+---
+spring:
+  redis:
+    host: localhost
+    port: 6379


### PR DESCRIPTION
## 개요
- 로그아웃 api 구현하였습니다.

## 작업사항
- 엑세스 토큰으로 리프레시 토큰의 역할까지 하려다보니까 엑세스토큰의 만료시간을 360000000 로 수정하게 되었습니다(환경변수변경해주세요)
- 토큰을 레디스에 저장해두었다가 로그아웃하게 될 때 레디스에 저장된 토큰을 삭제시켜 유효성 검사를 진행하였습니다.
- 토큰 인터셉터와 WebMvcConfig 를 통해 모든 api 요청에 동일하게 레디스에 들어있는 토큰을 받았는지 검사할 수 있도록 코드 구현하였습니다.

## 주의사항
- 레디스는 제 로컬에서 설치해서 돌려보았을 때에는 키값들이 잘 저장되는 것을 확인해보았는데, 문제가 없이 머지되면 서버에도 레디스 설치해서 확인하는 작업이 필요할 것 같습니다.

<img width="435" alt="스크린샷 2024-02-19 오후 3 29 05" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/122519994/2e77d2d7-88d2-4c7a-88b3-237acaae046e">

- postman 에서 로그아웃 성공한 결과입니다.

<img width="435" alt="스크린샷 2024-02-19 오후 3 28 37" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/122519994/6300b60e-91a1-44f1-8190-ebe4d3cf2694">

- 동일한 토큰으로 로그아웃 요청시 에러메세지입니다.
- 로그아웃 된 토큰으로 다른 api 요청을 보내보았을 때 "유효하지 않은 토큰입니다."라는 에러메세지 뜨도록 구현하였습니다. 이 부분도 확인해 보았습니다.