### PR TITLE
Feat: Meal-33-BE-회원탈퇴api

### DIFF
--- a/src/main/java/mealplanb/server/controller/MemberController.java
+++ b/src/main/java/mealplanb/server/controller/MemberController.java
@@ -60,6 +60,17 @@ public class MemberController {
     }
 
     /**
+     * 회원 탈퇴
+     */
+    @PatchMapping("")
+    public BaseResponse<Void> deleteMember(@RequestHeader("Authorization") String authorization){
+        log.info("[MemberController.deleteMember]");
+        String jwtToken = jwtProvider.extractJwtToken(authorization);
+        memberService.deleteMember(jwtToken);
+        return new BaseResponse<>(null);
+    }
+
+    /**
      * 아바타 정보 조회
      * */
     @GetMapping("/avatar")
@@ -84,7 +95,7 @@ public class MemberController {
      */
     @PatchMapping("/avatar/appearance")
     public BaseResponse<PatchAvatarAppearanceResponse> modifyAvatarAppearance(@Validated @RequestBody PatchAvatarAppearanceRequest patchAvatarAppearanceRequest,
-            @RequestHeader("Authorization") String authorization){
+                                                                              @RequestHeader("Authorization") String authorization){
         log.info("[MemberController.modifyAvatarAppearance]");
         Long memberId = jwtProvider.extractIdFromHeader(authorization);
         return new BaseResponse<>(memberService.modifyAvatarAppearance(memberId,patchAvatarAppearanceRequest));

--- a/src/main/java/mealplanb/server/domain/Member/Member.java
+++ b/src/main/java/mealplanb/server/domain/Member/Member.java
@@ -1,10 +1,7 @@
 package mealplanb.server.domain.Member;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import mealplanb.server.domain.*;
 import mealplanb.server.domain.Base.BaseTimeEntity;
 import mealplanb.server.domain.Meal.Meal;
@@ -20,8 +17,8 @@ import java.util.List;
 @Entity
 @Getter
 @Setter
-@ToString
 @NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "member")
 public class Member extends BaseTimeEntity {
     @Id
@@ -112,6 +109,10 @@ public class Member extends BaseTimeEntity {
         this.bodyFatMass = bodyFatMass;
         this.status = status;
         this.targetUpdatedAt = LocalDate.now();
+    }
+
+    public void updateStatus(MemberStatus status) {
+        this.status = status;
     }
 
 }

--- a/src/main/java/mealplanb/server/repository/MemberRepository.java
+++ b/src/main/java/mealplanb/server/repository/MemberRepository.java
@@ -1,14 +1,15 @@
 package mealplanb.server.repository;
 
 import mealplanb.server.domain.Member.Member;
+import mealplanb.server.domain.Member.MemberStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import javax.swing.text.html.Option;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findById(Long memberId);
+    Optional<Member> findByMemberId(Long memberId);
     Optional<Member> findByEmail(String email);
-    boolean existsByEmail(String email); // 이메일 중복 확인
+    boolean existsByEmailAndStatus(String email, MemberStatus a); // 이메일 중복 확인
+    boolean existsByMemberIdAndStatus(Long memberId, MemberStatus a);
 }


### PR DESCRIPTION
## 개요
- 탈퇴를 요청하면 회원상태를 D 로 만드는 회원탈퇴api 작업 수행하였습니다.

## 작업사항
- 헤더에 토큰을 포함해서 요청을 받으면 레디스에서 해당 토큰이 있는지 확인하고 있다면 레디스에서 지워버리는 방식으로 구현하였습니다.
- 작업을 하는 도중에 회원가입할 때 중복 이메일을 체크하는 레포지토리 메소드가 있었는데, 기존 방식대로라면 D 상태인 유저의 이메일까지도 중복검사를 하게되는 문제점을 발견해서 회원가입쪽 서비스 코드를 existsByEmail -> existsByEmailAndStatus 이렇게 수정하는 작업까지 함께 진행하였습니다.

## 주의사항
```
http://localhost:9000/user
```
<img width="481" alt="스크린샷 2024-02-19 오후 10 57 35" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/122519994/0ae71509-7365-447c-99d3-f6b46a4fd716">

- postman 테스트 결과입니다.

<img width="481" alt="스크린샷 2024-02-19 오후 10 58 00" src="https://github.com/KUIT2-MealplanB/mealplanb_server/assets/122519994/5ef452c3-96ee-4887-8555-217d11bfc384">

- 데이터베이스에서 유저 상태가 D 로 바뀐 것도 확인하였습니다.